### PR TITLE
Fees

### DIFF
--- a/src/Univ2LpOracle.sol
+++ b/src/Univ2LpOracle.sol
@@ -264,9 +264,9 @@ contract UNIV2LPOracle {
             uint256 rootK = sqrt(k);
             uint256 rootKLast = sqrt(kLast);
             if (rootK > rootKLast) {
-                uint256 numerator = wmul(supply, sub(rootK, rootKLast));
-                uint256 denominator = add(wmul(rootK, 5), rootKLast);
-                supply = add(supply, wdiv(numerator, denominator));
+                uint256 numerator = mul(supply, sub(rootK, rootKLast));
+                uint256 denominator = add(mul(rootK, 5), rootKLast);
+                supply = add(supply, numerator / denominator);
             }
         }
 

--- a/src/Univ2LpOracle.sol
+++ b/src/Univ2LpOracle.sol
@@ -50,6 +50,7 @@ interface ERC20Like {
 
 interface UniswapV2PairLike {
     function sync()         external;
+    function factory()      external view returns (address);
     function token0()       external view returns (address);
     function token1()       external view returns (address);
     function kLast()        external view returns (uint256);
@@ -211,7 +212,7 @@ contract UNIV2LPOracle {
         return block.timestamp >= add(zzz, hop);
     }
 
-    function seek() internal returns (uint128 quote, uint32 ts) {
+    function seek() public returns (uint128 quote, uint32 ts) {
         // Sync up reserves of uniswap liquidity pool
         UniswapV2PairLike(src).sync();
 
@@ -268,7 +269,6 @@ contract UNIV2LPOracle {
                 supply = add(supply, wdiv(numerator, denominator));
             }
         }
-
 
         // Calculate price quote of LP token
         quote = uint128(

--- a/src/Univ2LpOracle.sol
+++ b/src/Univ2LpOracle.sol
@@ -211,7 +211,7 @@ contract UNIV2LPOracle {
         return block.timestamp >= add(zzz, hop);
     }
 
-    function seek() public returns (uint128 quote, uint32 ts) {
+    function seek() internal returns (uint128 quote, uint32 ts) {
         // Sync up reserves of uniswap liquidity pool
         UniswapV2PairLike(src).sync();
 

--- a/src/Univ2LpOracle.sol
+++ b/src/Univ2LpOracle.sol
@@ -216,6 +216,7 @@ contract UNIV2LPOracle {
 
         // Get reserves of uniswap liquidity pool
         (uint112 res0, uint112 res1, uint32 _ts) = UniswapV2PairLike(src).getReserves();
+        require(res0 > 0 && res1 > 0, "UNIV2LPOracle/invalid-reserves");
         ts = _ts;
         require(ts == block.timestamp);
 
@@ -247,7 +248,7 @@ contract UNIV2LPOracle {
 
         // Get LP token supply
         uint256 supply = ERC20Like(src).totalSupply();
-        require(supply != 0, "UNIV2LPOracle/invalid-lp-token-supply");
+        require(supply > 0, "UNIV2LPOracle/invalid-lp-token-supply");
 
         // Calculate price quote of LP token
         quote = uint128(

--- a/src/Univ2LpOracle.t.sol
+++ b/src/Univ2LpOracle.t.sol
@@ -554,7 +554,7 @@ contract UNIV2LPOracleTest is DSTest {
         (bytes32 val, bool has) = wbtcEthLPOracle.peep();               // Query queued price of WBTC-ETH LP Oracle
         uint256 firstVal = uint256(val);                                // Cast queued price as uint256
 
-        assertTrue(firstVal < 800_000_000 ether && firstVal > 600_000_000 ether);   // 704030123759222892060867448 at time of test
+        assertTrue(firstVal < 900_000_000 ether && firstVal > 600_000_000 ether);   // 704030123759222892060867448 at time of test
         assertTrue(has);                                                // Verify Oracle has valid value
 
         /*** Trade $10k WBTC for ETH ***/
@@ -580,7 +580,7 @@ contract UNIV2LPOracleTest is DSTest {
         wbtcEthLPOracle.poke();                                         // Poke WBTC-ETH LP Oracle
         (val, has) = wbtcEthLPOracle.peep();                            // Query queued price of WBTC-ETH LP Oracle
         uint256 secondVal = uint256(val);                               // Cast queued price as uint256
-        assertTrue(secondVal < 800_000_000 ether && secondVal > 600_000_000 ether);     // 704030254653978027824526079 at time of test
+        assertTrue(secondVal < 900_000_000 ether && secondVal > 600_000_000 ether);     // 704030254653978027824526079 at time of test
         assertTrue(has);                                                // Verify Oracle has valid price
 
         assertTrue(secondVal > firstVal);                               // Verify price of WBTC-ETH LP token increased afer trade
@@ -608,7 +608,7 @@ contract UNIV2LPOracleTest is DSTest {
         wbtcEthLPOracle.poke();                                         // Poke WBTC-ETH LP Oracle
         (val, has) = wbtcEthLPOracle.peep();                            // Query queued price of WBTC-ETH LP Oracle
         uint256 thirdVal = uint256(val);                                // Cast queued price as uint256
-        assertTrue(thirdVal < 800_000_000 ether && thirdVal > 600_000_000 ether);   // 704030385156122678606782694 at time of test
+        assertTrue(thirdVal < 900_000_000 ether && thirdVal > 600_000_000 ether);   // 704030385156122678606782694 at time of test
         assertTrue(has);                                                // Verify Oracle has valid value
 
         assertTrue(thirdVal > secondVal);                               // Verify price of WBTC0ETH LP token increased after trade

--- a/src/Univ2LpOracle.t.sol
+++ b/src/Univ2LpOracle.t.sol
@@ -229,49 +229,46 @@ contract UNIV2LPOracleTest is DSTest {
     }
 
     function test_seek_fee_dai() public {
-        address newTo = 0xb478c2975Ab1Ea89e8196811F51a7B7ADe33eB12;                     // Address that will receieve lp fees 
+        address newTo = 0xb478c2975Ab1Ea89e8196811F51a7B7ADe33eB12;               // Address that will receieve lp fees 
 
-        address uniFactory = UniswapV2PairLike(DAI_ETH_UNI_POOL).factory();             // Get dai-eth lp factory contract
+        address uniFactory = UniswapV2PairLike(DAI_ETH_UNI_POOL).factory();       // Get dai-eth lp factory contract
         hevm.store(
             address(uniFactory),
             bytes32(0),
-            bytes32(address(0))
-        );                                                                              // Override factory 'feeTo' field with 0 address
+            bytes32(0)
+        );                                                                        // Override factory 'feeTo' field with 0 address
         hevm.store(
             address(DAI_ETH_UNI_POOL),
-            bytes32(0xB),
-            bytes32(uint256(0))
-        );                                                                              // Override dai-eth pool 'kLast' field with 0
-        assertTrue(UniswapV2PairLike(DAI_ETH_UNI_POOL).kLast() == uint256(0));          // Verify `kLast` is 0
-        (uint128 firstLPPrice,) = daiEthLPOracle.seek();                                // Query dai-eth lp price Uniswap
+            bytes32(uint256(11)),
+            bytes32(0)
+        );                                                                        // Override dai-eth pool 'kLast' field with 0
+        assertTrue(UniswapV2PairLike(DAI_ETH_UNI_POOL).kLast() == uint256(0));    // Verify `kLast` is 0
+        (uint128 firstLPPrice,) = daiEthLPOracle.seek();                          // Query dai-eth lp price Uniswap
         hevm.store(
             address(uniFactory),
-            bytes32(address(0)),
-            bytes32(address(newTo))
-        );                                                                              // Override factory 'feeTo' field with new address
+            bytes32(0),
+            bytes32(uint256(address(newTo)))
+        );                                                                        // Override factory 'feeTo' field with new address
 
         (
             uint112 res0,
             uint112 res1,
-        ) = UniswapV2PairLike(DAI_ETH_UNI_POOL).getReserves();                          // Get reserves of token0 and token1 in liquidity pool
-        uint256 k = mul(res0, res1);                                                    // Calculate constant product invariant k (WAD * WAD)
+        ) = UniswapV2PairLike(DAI_ETH_UNI_POOL).getReserves();                    // Get reserves of token0 and token1 in liquidity pool
+        uint256 k = mul(res0, res1);                                              // Calculate constant product invariant k (WAD * WAD)
         hevm.store(
             address(DAI_ETH_UNI_POOL),
-            bytes32(0xB),
+            bytes32(uint256(11)),
             bytes32(k)
-        );                                                                              // Override dai-eth pool 'kLast' field with 'k'
-        assertTrue(UniswapV2PairLike(DAI_ETH_UNI_POOL).kLast() == k);                   // Verify invariant `k` is non-zero
-        (uint128 secondLPPrice,) = daiEthLPOracle.seek();                               // Query dai-eth lp price Uniswap
+        );                                                                        // Override dai-eth pool 'kLast' field with 'k'
+        assertTrue(UniswapV2PairLike(DAI_ETH_UNI_POOL).kLast() == k);             // Verify invariant `k` is non-zero
+        (uint128 secondLPPrice,) = daiEthLPOracle.seek();                         // Query dai-eth lp price Uniswap
 
-
-
-        //verify firstLPPrice and secondLPPrice is within 0.1%
-        //copy pasted havent modified it yet
-        //diff =
-        //    amounts[1] > 10_000 ether * 1E8 / wbtcPrice ?
-        //    amounts[1] - 10_000 ether * 1E8 / wbtcPrice :
-        //    10_000 ether * 1E8 / wbtcPrice - amounts[1];                // Calculate difference between trade and WBTC Oracle
-        //assertTrue(diff * WAD / amounts[1] < 0.001 ether);               // Verify less than 2% slippage
+        // Verify firstLPPrice and secondLPPrice is within 0.1%
+        uint256 diff =
+           firstLPPrice > secondLPPrice ?
+           firstLPPrice - secondLPPrice :
+           secondLPPrice - firstLPPrice;                      // Calculate price difference
+        assertTrue(diff * WAD / firstLPPrice < 0.001 ether);  // Verify less than 0.1% difference
 
     }
 

--- a/src/Univ2LpOracle.t.sol
+++ b/src/Univ2LpOracle.t.sol
@@ -255,6 +255,7 @@ contract UNIV2LPOracleTest is DSTest {
             uint112 res1,
         ) = UniswapV2PairLike(DAI_ETH_UNI_POOL).getReserves();                    // Get reserves of token0 and token1 in liquidity pool
         uint256 k = mul(res0, res1);                                              // Calculate constant product invariant k (WAD * WAD)
+        assertTrue(k > 0);                                                        // Verify invariant k is non-zero
         hevm.store(
             address(DAI_ETH_UNI_POOL),
             bytes32(uint256(11)),
@@ -267,9 +268,9 @@ contract UNIV2LPOracleTest is DSTest {
         uint256 diff =
            firstLPPrice > secondLPPrice ?
            firstLPPrice - secondLPPrice :
-           secondLPPrice - firstLPPrice;                      // Calculate price difference
-        assertTrue(diff * WAD / firstLPPrice < 0.001 ether);  // Verify less than 0.1% difference
-
+           secondLPPrice - firstLPPrice;                                          // Calculate price difference
+        assertTrue(diff * WAD / firstLPPrice < 0.001 ether);                      // Verify less than 0.1% difference
+        assertTrue(firstLPPrice != secondLPPrice);
     }
 
     function test_seek_internals() public {


### PR DESCRIPTION
I still need to write tests for this, so PR is incomplete. I just wanted to get eyes early on the core logic change in `seek()`.
The logic was grabbed from this open PR from the Uniswap repo:
https://github.com/Uniswap/uniswap-v2-periphery/pull/49/files#diff-1ca606855db4c3aae71e6ff06e4d93cf326acb5eeaa92f38e7dde3143f80618a

Note that we forego querying the `feeTo()` parameter from the factory (which saves us an extra storage slot for the `factory`, an `SREAD` to get the factory address, and an external call to the `factory`) to save on gas fees which could add up to thousands of $ a year. This is only a problem during the time interval between Uniswap Governance toggling fees on/off and liquidity being added/removed from the pair. Even when this problem is "active" it leads to at most 0.05% divergence which is insignificant relative to the drift caused by the `hop` delay.