### PR TITLE
store zzz as a multiple of hop

### DIFF
--- a/src/Univ2LpOracle.sol
+++ b/src/Univ2LpOracle.sol
@@ -106,7 +106,7 @@ contract UNIV2LPOracle {
 
     uint32  public hop = 1 hours;   // Minimum time inbetween price updates
     address public src;             // Price source
-    uint32  public zzz;             // Time of last price update
+    uint64  public zzz;             // Time of last price update
 
     struct Feed {
         uint128 val;  // Price

--- a/src/Univ2LpOracle.sol
+++ b/src/Univ2LpOracle.sol
@@ -190,6 +190,11 @@ contract UNIV2LPOracle {
         emit Change(src);
     }
 
+    function prev(uint ts) internal view returns (uint64) {
+        require(hop != 0, "UNIV2LPOracle/hop-is-zero");
+        return uint64(ts - (ts % hop));
+    }
+
     function step(uint256 _hop) external auth {
         require(_hop <= uint32(-1), "UNIV2LPOracle/invalid-hop");
         hop = uint32(_hop);
@@ -268,7 +273,7 @@ contract UNIV2LPOracle {
         require(val != 0, "UNIV2LPOracle/invalid-price");
         cur = nxt;
         nxt = Feed(uint128(val), 1);
-        zzz = ts;
+        zzz = prev(ts);
         emit Value(cur.val, nxt.val);
     }
 


### PR DESCRIPTION
Instead of storing the current timestamp in the `zzz` variable, store the latest multiple of `hop`.

This allows for this OSM to be updatable at the top of the hour like other OSMs.