### PR TITLE
OSM memory slot parity

### DIFF
--- a/src/Univ2LpOracle.sol
+++ b/src/Univ2LpOracle.sol
@@ -93,28 +93,29 @@ contract UNIV2LPOracle {
     uint256 public stopped;  // Stop/start ability to read
     modifier stoppable { require(stopped == 0, "UNIV2LPOracle/is-stopped"); _; }
 
-    // --- Whitelisting ---
-    mapping (address => uint256) public bud;
-    modifier toll { require(bud[msg.sender] == 1, "UNIV2LPOracle/contract-not-whitelisted"); _; }
+    address public src;             // Price source
+    uint16  public hop = 1 hours;   // Minimum time inbetween price updates
+    uint64  public zzz;             // Time of last price update
 
     // --- Data ---
     uint8   public immutable dec0;  // Decimals of token0
     uint8   public immutable dec1;  // Decimals of token1
-    address public           orb0;  // Oracle for token0, ideally a Medianizer
-    address public           orb1;  // Oracle for token1, ideally a Medianizer
-    bytes32 public immutable wat;   // Token whose price is being tracked
-
-    uint32  public hop = 1 hours;   // Minimum time inbetween price updates
-    address public src;             // Price source
-    uint32  public zzz;             // Time of last price update
 
     struct Feed {
         uint128 val;  // Price
         uint128 has;  // Is price valid
     }
 
-    Feed    public cur;  // Current price
-    Feed    public nxt;  // Queued price
+    Feed    public cur;  // Current price  (mem slot 0x3)
+    Feed    public nxt;  // Queued price   (mem slot 0x4)
+
+    // --- Whitelisting ---
+    mapping (address => uint256) public bud;
+    modifier toll { require(bud[msg.sender] == 1, "UNIV2LPOracle/contract-not-whitelisted"); _; }
+
+    address public           orb0;  // Oracle for token0, ideally a Medianizer
+    address public           orb1;  // Oracle for token1, ideally a Medianizer
+    bytes32 public immutable wat;   // Token whose price is being tracked
 
     // --- Math ---
     uint256 constant WAD = 10 ** 18;
@@ -191,8 +192,8 @@ contract UNIV2LPOracle {
     }
 
     function step(uint256 _hop) external auth {
-        require(_hop <= uint32(-1), "UNIV2LPOracle/invalid-hop");
-        hop = uint32(_hop);
+        require(_hop <= uint16(-1), "UNIV2LPOracle/invalid-hop");
+        hop = uint16(_hop);
         emit Step(hop);
     }
 

--- a/src/Univ2LpOracle.t.sol
+++ b/src/Univ2LpOracle.t.sol
@@ -10,6 +10,7 @@ import "./Univ2LpOracle.sol";
 interface Hevm {
     function warp(uint256) external;
     function store(address,bytes32,bytes32) external;
+    function load(address, bytes32 slot) external returns (bytes32);
 }
 
 interface OSMLike {
@@ -644,5 +645,55 @@ contract UNIV2LPOracleTest is DSTest {
         assertTrue(has);                                                // Verify Oracle has valid value
 
         assertTrue(thirdVal > secondVal);                               // Verify price of WBTC0ETH LP token increased after trade
+    }
+
+    function testCurSlot0x3() public {
+        daiEthLPOracle.poke();                                       // Poke oracle
+        hevm.warp(add(daiEthLPOracle.zzz(), daiEthLPOracle.hop()));  // Time travel into the future
+        daiEthLPOracle.poke();                                       // Poke oracle again
+        daiEthLPOracle.kiss(address(this));                          // Whitelist caller
+        (bytes32 val, bool has) = daiEthLPOracle.peek();             // Peek oracle price without caller being whitelisted
+        assertTrue(has);                                             // Verify oracle has value
+        assertTrue(val != bytes32(0));                               // Verify peep returned valid value
+
+        // Load memory slot 0x3
+        // Keeps `cur` slot parity with OSMs
+        bytes32 curPacked = hevm.load(address(daiEthLPOracle), bytes32(uint256(3)));
+
+        bytes16 memhas;
+        bytes16 memcur;
+        assembly {
+            memhas := curPacked
+            memcur := shl(128, curPacked)
+        }
+
+        assertTrue(uint256(uint128(memcur)) > 0);          // Assert nxt has value
+        assertEq(uint256(val), uint256(uint128(memcur)));  // Assert slot value == cur
+        assertEq(uint256(uint128(memhas)), 1);             // Assert slot has == 1
+    }
+
+    function testNxtSlot0x4() public {
+        daiEthLPOracle.poke();                                       // Poke oracle
+        hevm.warp(add(daiEthLPOracle.zzz(), daiEthLPOracle.hop()));  // Time travel into the future
+        daiEthLPOracle.poke();                                       // Poke oracle again
+        daiEthLPOracle.kiss(address(this));                          // Whitelist caller
+        (bytes32 val, bool has) = daiEthLPOracle.peep();             // Peep oracle price without caller being whitelisted
+        assertTrue(has);                                             // Verify oracle has value
+        assertTrue(val != bytes32(0));                               // Verify peep returned valid value
+
+        // Load memory slot 0x4
+        // Keeps `nxt` slot parity with OSMs
+        bytes32 nxtPacked = hevm.load(address(daiEthLPOracle), bytes32(uint256(4)));
+
+        bytes16 memhas;
+        bytes16 memnxt;
+        assembly {
+            memhas := nxtPacked
+            memnxt := shl(128, nxtPacked)
+        }
+
+        assertTrue(uint256(uint128(memnxt)) > 0);          // Assert nxt has value
+        assertEq(uint256(val), uint256(uint128(memnxt)));  // Assert slot value == nxt
+        assertEq(uint256(uint128(memhas)), 1);             // Assert slot has == 1
     }
 }

--- a/src/Univ2LpOracle.t.sol
+++ b/src/Univ2LpOracle.t.sol
@@ -713,7 +713,7 @@ contract UNIV2LPOracleTest is DSTest {
         assertTrue(thirdVal > secondVal);                               // Verify price of WBTC0ETH LP token increased after trade
     }
 
-    // This test will fail if the value of `val` at peep does not match memory slot 0x3
+    // This test will fail if the value of `val` at peek does not match memory slot 0x3
     function testCurSlot0x3() public {
         daiEthLPOracle.poke();                                       // Poke oracle
         hevm.warp(add(daiEthLPOracle.zzz(), daiEthLPOracle.hop()));  // Time travel into the future
@@ -739,7 +739,7 @@ contract UNIV2LPOracleTest is DSTest {
         assertEq(uint256(uint128(memhas)), 1);             // Assert slot has == 1
     }
 
-    // This test will fail if the value of `nxt` at peep does not match memory slot 0x4
+    // This test will fail if the value of `val` at peep does not match memory slot 0x4
     function testNxtSlot0x4() public {
         daiEthLPOracle.poke();                                       // Poke oracle
         hevm.warp(add(daiEthLPOracle.zzz(), daiEthLPOracle.hop()));  // Time travel into the future

--- a/src/test/IERC20.sol
+++ b/src/test/IERC20.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 pragma solidity >=0.5.0;
 
 interface IERC20 {

--- a/src/test/IUniswapV2Router01.sol
+++ b/src/test/IUniswapV2Router01.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity >=0.6.2;
 
 interface IUniswapV2Router01 {

--- a/src/test/IUniswapV2Router02.sol
+++ b/src/test/IUniswapV2Router02.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity >=0.6.2;
 
 import './IUniswapV2Router01.sol';


### PR DESCRIPTION
Refactors the LP oracle to memory slot parity with the OSMs

Puts `cur` in slot 0x3 and `nxt` in slot 0x4, and moves other variables to match as well.

Other projects like zapper and defisaver are using the slot locations to read prices for UI's, this provides a familiar data mapping.