### PR TITLE
Gas optimizations and test improvements

### DIFF
--- a/src/Univ2LpOracle.sol
+++ b/src/Univ2LpOracle.sol
@@ -38,8 +38,8 @@
 // Now that we've calculated normalized values of r_x and r_y that are not prone to manipulation by an attacker,
 // we can calculate the price of an lp token using the following formula.
 //
-// p_lp = (r_x * p_x + r_y * p_y) / supply_lp
-//
+// p_lp = (r_x * p_x + r_y * p_y) / supply_lp = 2 * sqrt(k * p_x * p_y) / supply_lp
+
 pragma solidity ^0.6.11;
 
 interface ERC20Like {

--- a/src/Univ2LpOracle.sol
+++ b/src/Univ2LpOracle.sol
@@ -244,10 +244,8 @@ contract UNIV2LPOracle {
         // No need to check that the supply is nonzero, Solidity reverts on division by zero.
 
         quote = uint128(
-            wdiv(
-                mul(2, sqrt(wmul(k, wmul(val0, val1)))),
-                supply
-            )
+                mul(2 * WAD, sqrt(wmul(k, wmul(val0, val1))))
+                    / supply
         );
     }
 

--- a/src/Univ2LpOracle.sol
+++ b/src/Univ2LpOracle.sol
@@ -98,11 +98,11 @@ contract UNIV2LPOracle {
     modifier toll { require(bud[msg.sender] == 1, "UNIV2LPOracle/contract-not-whitelisted"); _; }
 
     // --- Data ---
-    uint256 public immutable normalizer0;  // Multiplicative factor that normalizes a token0 balance to a WAD; 10^(18 - dec)
-    uint256 public immutable normalizer1;  // Multiplicative factor that normalizes a token1 balance to a WAD; 10^(18 - dec)
-    address public           orb0;  // Oracle for token0, ideally a Medianizer
-    address public           orb1;  // Oracle for token1, ideally a Medianizer
-    bytes32 public immutable wat;   // Token whose price is being tracked
+    uint256 private immutable normalizer0;  // Multiplicative factor that normalizes a token0 balance to a WAD; 10^(18 - dec)
+    uint256 private immutable normalizer1;  // Multiplicative factor that normalizes a token1 balance to a WAD; 10^(18 - dec)
+    address public            orb0;  // Oracle for token0, ideally a Medianizer
+    address public            orb1;  // Oracle for token1, ideally a Medianizer
+    bytes32 public  immutable wat;   // Token whose price is being tracked
 
     uint32  public hop = 1 hours;   // Minimum time inbetween price updates
     address public src;             // Price source
@@ -169,10 +169,8 @@ contract UNIV2LPOracle {
         src  = _src;
         zzz  = 0;
         wat  = _wat;
-        normalizer0 = 10 ** sub(18, uint8(ERC20Like(UniswapV2PairLike(_src).token0()).decimals()));  // Calculate normalization factor of token0
-        normalizer1 = 10 ** sub(18, uint8(ERC20Like(UniswapV2PairLike(_src).token1()).decimals()));  // Calculate normalization factor of token1
-        require(_normalizer1 >= 1);
-        normalizer1 = _normalizer1;
+        normalizer0 = 10 ** sub(18, uint256(ERC20Like(UniswapV2PairLike(_src).token0()).decimals()));  // Calculate normalization factor of token0
+        normalizer1 = 10 ** sub(18, uint256(ERC20Like(UniswapV2PairLike(_src).token1()).decimals()));  // Calculate normalization factor of token1
         orb0 = _orb0;
         orb1 = _orb1;
     }

--- a/src/Univ2LpOracle.sol
+++ b/src/Univ2LpOracle.sol
@@ -169,10 +169,8 @@ contract UNIV2LPOracle {
         src  = _src;
         zzz  = 0;
         wat  = _wat;
-        uint256 _normalizer0 = 10 ** sub(18, uint8(ERC20Like(UniswapV2PairLike(_src).token0()).decimals()));  // Calculate normalization factor of token0
-        require(_normalizer0 >= 1);
-        normalizer0 = _normalizer0;
-        uint256 _normalizer1 = 10 ** sub(18, uint8(ERC20Like(UniswapV2PairLike(_src).token1()).decimals()));  // Calculate normalization factor of token0
+        normalizer0 = 10 ** sub(18, uint8(ERC20Like(UniswapV2PairLike(_src).token0()).decimals()));  // Calculate normalization factor of token0
+        normalizer1 = 10 ** sub(18, uint8(ERC20Like(UniswapV2PairLike(_src).token1()).decimals()));  // Calculate normalization factor of token1
         require(_normalizer1 >= 1);
         normalizer1 = _normalizer1;
         orb0 = _orb0;

--- a/src/Univ2LpOracle.t.sol
+++ b/src/Univ2LpOracle.t.sol
@@ -401,39 +401,20 @@ contract UNIV2LPOracleTest is DSTest {
         assertTrue(val1 > 0);                                                     // Verify token1 price is valid
         /*** END TEST 4 ***/
 
-        uint bal0 = sqrt(wmul(k, wdiv(val1, val0)));                              // Calculate normalized token0 balance (WAD)
-        uint bal1 = wdiv(k, bal0) / WAD;                                          // Calculate normalized token1 balance
-
-        /*** BEGIN TEST 5 ***/
-        // Verify normalized reserves are within 1.3% margin of actual reserves
-        // During times of high price volatility this condition may not hold
-        assertTrue(bal0 > 0);                                                     // Verify normalized token0 balance is valid
-        assertTrue(bal1 > 0);                                                     // Verify normalized token1 balance is valid
-        uint diff0 = uint(res0) > bal0 ? uint(res0) - bal0 : bal0 - uint(res0);
-        uint diff1 = uint(res1) > bal1 ? uint(res1) - bal1 : bal1 - uint(res1);
-        assertTrue(diff0 * RAY / bal0 < 1 * RAY / 100);                           // Verify normalized token0 balance is within 1.3% of token0 balance
-        assertTrue(diff1 * RAY / bal1 < 1 * RAY / 100);                           // Verify normalized token1 balance is within 1.3% of token0 balance
-        /*** END TEST 5 ***/
-
         uint supply = ERC20Like(WBTC_ETH_UNI_POOL).totalSupply();                 // Get LP token supply
 
-        /*** BEGIN TEST 6 ***/
+        /*** BEGIN TEST 5 ***/
         assertTrue(supply > WAD / 1000);                                          // Verify LP token supply is valid (supply can be less than WAD if price > mkt cap)
-        /*** END TEST 6 ***/
+        /*** END TEST 5 ***/
 
         uint128 quote = uint128(                                                  // Calculate LP token price quote
-            wdiv(
-                add(
-                    wmul(bal0, val0), // (WAD)
-                    wmul(bal1, val1)  // (WAD)
-                ),
-                supply // (WAD)
-            )
+                mul(2 * WAD, sqrt(wmul(k, wmul(val0, val1))))
+                    / supply
         );
 
-        /*** BEGIN TEST 7 ***/
+        /*** BEGIN TEST 6 ***/
         assertTrue(quote > WAD);                                                  // Verify LP token price quote is valid
-        /*** END TEST 7 ***/
+        /*** END TEST 6 ***/
 
         ///////////////////////////////////////
         //                                   //

--- a/src/Univ2LpOracle.t.sol
+++ b/src/Univ2LpOracle.t.sol
@@ -96,6 +96,59 @@ contract UNIV2LPOracleTest is DSTest {
         hevm = Hevm(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);                  // Configure hevm
         hevm.warp(now);                                                           // Set time to latest block
 
+        // Set relevant storage values as they were in block 11461654
+        hevm.store(
+            DAI_ETH_UNI_POOL,
+            0,                                                                    // totalSupply
+            bytes32(uint256(1882428696129524169269340))
+        );
+        hevm.store(
+            DAI_ETH_UNI_POOL,
+            bytes32(uint256(8)),                                                  // reserve0, reserve1, and blockTimestampLast
+            bytes32(uint256(43353987475243871752608912172418385489740068120774565181786433903143712498119))
+        );
+        hevm.store(
+            DAI,
+            keccak256(abi.encode(DAI_ETH_UNI_POOL, uint256(2))),                  // DAI balance of DAI_ETH pool
+            bytes32(uint(55130522579388813557146055))
+        );
+        hevm.store(
+            WETH,
+            keccak256(abi.encode(DAI_ETH_UNI_POOL, uint256(3))),                  // WETH balance of DAI_ETH pool
+            bytes32(uint(94328066153704376274664))
+        );
+        hevm.store(
+            WBTC_ETH_UNI_POOL,
+            0,                                                                    // totalSupply
+            bytes32(uint256(185917965159193313))
+        );
+        hevm.store(
+            WBTC_ETH_UNI_POOL ,
+            bytes32(uint256(8)),                                                  // reserve0, reserve1, and blockTimestampLast
+            bytes32(uint256(43353988796281258443110612805302462270865328117852610699179961909467622877495))
+        );
+        hevm.store(
+            WETH,
+            keccak256(abi.encode(WBTC_ETH_UNI_POOL, uint256(3))),                 // WETH balance of WBTC_ETH pool
+            bytes32(uint(117506766732526502569271))
+        );
+        hevm.store(
+            WBTC,
+            keccak256(abi.encode(WBTC_ETH_UNI_POOL, uint256(0))),                 // WBTC balance of WBTC_ETH pool
+            bytes32(uint(353924491575))
+        );
+        hevm.store(
+            ETH_ORACLE,
+            bytes32(uint256(3)),                                                  // cur
+            bytes32(uint256(340282366920938464048374607431768211456))
+        );
+        hevm.store(
+            WBTC_ORACLE,
+            bytes32(uint256(3)),                                                  // cur
+            bytes32(uint256(340282366920938482841324607431768211456))
+        );
+        hevm.warp(1608088819);  // block.timestamp for block 11461654
+
         factory = new UNIV2LPOracleFactory();                                     // Instantiate new factory
 
         daiEthLPOracle = UNIV2LPOracle(factory.build(

--- a/src/Univ2LpOracle.t.sol
+++ b/src/Univ2LpOracle.t.sol
@@ -167,7 +167,7 @@ contract UNIV2LPOracleTest is DSTest {
         seekableOracleDAI = new SeekableOracle(DAI_ETH_UNI_POOL, poolNameDAI, USDC_ORACLE, ETH_ORACLE);
         seekableOracleDAI.rely(msg.sender);
         hevm.store(
-            address(ETH_ORACLE),
+            ETH_ORACLE,
             keccak256(abi.encode(address(seekableOracleDAI), uint256(5))),
             bytes32(uint256(1))
         );
@@ -175,29 +175,29 @@ contract UNIV2LPOracleTest is DSTest {
         seekableOracleWBTC = new SeekableOracle(WBTC_ETH_UNI_POOL, poolNameWBTC, WBTC_ORACLE, ETH_ORACLE);
         seekableOracleWBTC.rely(msg.sender);
         hevm.store(
-            address(ETH_ORACLE),
+            ETH_ORACLE,
             keccak256(abi.encode(address(seekableOracleWBTC), uint256(5))),
             bytes32(uint256(1))
         );                                                                        // Whitelist DAI-ETH LP Oracle on seekable ETH Oracle
         hevm.store(
-            address(WBTC_ORACLE),
+            WBTC_ORACLE,
             keccak256(abi.encode(address(seekableOracleWBTC), uint256(5))),
             bytes32(uint256(1))
         );
 
 
         hevm.store(
-            address(ETH_ORACLE),
+            ETH_ORACLE,
             keccak256(abi.encode(address(daiEthLPOracle), uint256(5))),
             bytes32(uint256(1))
         );                                                                        // Whitelist DAI-ETH LP Oracle on ETH Oracle
         hevm.store(
-            address(WBTC_ORACLE),
+            WBTC_ORACLE,
             keccak256(abi.encode(address(wbtcEthLPOracle), uint256(5))),
             bytes32(uint256(1))
         );                                                                        // Whitelist WBTC-ETH LP Oracle on WBTC Oracle
         hevm.store(
-            address(ETH_ORACLE),
+            ETH_ORACLE,
             keccak256(abi.encode(address(wbtcEthLPOracle), uint256(5))),
             bytes32(uint256(1))
         );                                                                        // Whitelist WBTC-ETH LP Oracle on ETH Oracle
@@ -207,14 +207,14 @@ contract UNIV2LPOracleTest is DSTest {
         IERC20(WETH).approve(UNISWAP_ROUTER_02, uint(-1));                        // Approve WETH to trade on Uniswap
 
         hevm.store(
-            address(DAI),
+            DAI,
             keccak256(abi.encode(address(this), uint256(2))),
             bytes32(uint(10_000 ether))
         );                                                                        // Mint 10,000 DAI
         IERC20(DAI).approve(UNISWAP_ROUTER_02, uint(-1));                         // Approve DAI to trade on Uniswap
 
         hevm.store(
-            address(ETH_ORACLE),
+            ETH_ORACLE,
             keccak256(abi.encode(address(this), uint256(5))),
             bytes32(uint256(1))
         );                                                                        // Whitelist caller on ETH Oracle
@@ -222,7 +222,7 @@ contract UNIV2LPOracleTest is DSTest {
         ethPrice = uint256(val);                                                  // Cast ETH/USD price as uint256
 
         hevm.store(
-            address(WBTC_ORACLE),
+            WBTC_ORACLE,
             keccak256(abi.encode(address(this), uint256(5))),
             bytes32(uint256(1))
         );                                                                        // Whitelist caller on WBTC Oracle
@@ -232,7 +232,7 @@ contract UNIV2LPOracleTest is DSTest {
         // Mint $10k of WBTC
         wbtcMintAmt = 10_000 ether * 1E8 / wbtcPrice;                             // Calculate amount of WBTC worth $10,000
         hevm.store(
-            address(WBTC),
+            WBTC,
             keccak256(abi.encode(address(this), uint256(0))),
             bytes32(wbtcMintAmt)
         );                                                                        // Mint $10,000 worth of WBTC

--- a/src/Univ2LpOracle.t.sol
+++ b/src/Univ2LpOracle.t.sol
@@ -20,7 +20,7 @@ interface OSMLike {
 contract SeekableOracle is UNIV2LPOracle {
     constructor(address _src, bytes32 _wat, address _orb0, address _orb1) public UNIV2LPOracle(_src, _wat, _orb0, _orb1) {}
 
-    function extseek() public returns (uint128 quote, uint32 ts) {
+    function _seek() public returns (uint128 quote, uint32 ts) {
         return seek();
     }
 }
@@ -165,7 +165,6 @@ contract UNIV2LPOracleTest is DSTest {
         );                                                                        // Build new WBTC-ETH Uniswap LP Orace
 
         seekableOracleDAI = new SeekableOracle(DAI_ETH_UNI_POOL, poolNameDAI, USDC_ORACLE, ETH_ORACLE);
-        seekableOracleDAI.rely(msg.sender);
         hevm.store(
             ETH_ORACLE,
             keccak256(abi.encode(address(seekableOracleDAI), uint256(5))),
@@ -173,7 +172,6 @@ contract UNIV2LPOracleTest is DSTest {
         );
 
         seekableOracleWBTC = new SeekableOracle(WBTC_ETH_UNI_POOL, poolNameWBTC, WBTC_ORACLE, ETH_ORACLE);
-        seekableOracleWBTC.rely(msg.sender);
         hevm.store(
             ETH_ORACLE,
             keccak256(abi.encode(address(seekableOracleWBTC), uint256(5))),
@@ -303,13 +301,13 @@ contract UNIV2LPOracleTest is DSTest {
     }
 
     function test_seek_dai() public {
-        (uint128 lpTokenPrice, uint32 zzz) = seekableOracleDAI.extseek();         // Get new dai-eth lp price from uniswap
+        (uint128 lpTokenPrice, uint32 zzz) = seekableOracleDAI._seek();           // Get new dai-eth lp price from uniswap
         assertTrue(zzz > uint32(0));                                              // Verify timestamp was set
         assertTrue(uint256(lpTokenPrice) > WAD);                                  // Verify token price was set
     }
 
     function test_seek_wbtc() public {
-        (uint128 lpTokenPrice, uint32 zzz) = seekableOracleWBTC.extseek();        // Get new wbtc-eth lp price from uniswap
+        (uint128 lpTokenPrice, uint32 zzz) = seekableOracleWBTC._seek();          // Get new wbtc-eth lp price from uniswap
         assertTrue(zzz > uint32(0));                                              // Verify timestamp was set
         assertTrue(uint256(lpTokenPrice) > WAD);                                  // Verify token price was set
     }

--- a/src/Univ2LpOracle.t.sol
+++ b/src/Univ2LpOracle.t.sol
@@ -343,7 +343,7 @@ contract UNIV2LPOracleTest is DSTest {
             0,                                                                    // totalSupply
             bytes32(uint256(0))
         );
-        (uint128 lpTokenPrice128, uint32 zzz) = seekableOracleDAI._seek();        // Get new dai-eth lp price from uniswap
+        seekableOracleDAI._seek();                                                // Get new dai-eth lp price from uniswap
     }
 
     function test_seek_internals() public {
@@ -372,11 +372,11 @@ contract UNIV2LPOracleTest is DSTest {
         /*** END TEST 1 ***/
 
         // Adjust reserves w/ respect to decimals
-        if (wbtcEthLPOracle.normalizer0() > 1) {                                  // Check if token0 has non-standard decimals
-            res0 = uint112(res0 * wbtcEthLPOracle.normalizer0());                 // Adjust reserves of token0
+        if (ERC20Like(tok0).decimals() < 18) {                                        // Check if token0 has non-standard decimals
+            res0 = uint112(res0 * 10 ** (18 - uint256(ERC20Like(tok0).decimals())));  // Adjust reserves of token0
         }
-        if (wbtcEthLPOracle.normalizer1() > 1) {                                  // Check if token1 has non-standard decimals
-            res1 = uint112(res1 * wbtcEthLPOracle.normalizer1());                 // Adjust reserve of token1
+        if (ERC20Like(tok1).decimals() < 18) {                                        // Check if token1 has non-standard decimals
+            res1 = uint112(res1 * 10 ** (18 - uint256(ERC20Like(tok1).decimals())));  // Adjust reserves of token1
         }
         /*** BEGIN TEST 2 ***/
         assertEq(res1, ERC20Like(tok1).balanceOf(WBTC_ETH_UNI_POOL));             // Verify no adjustment for WETH (18 decimals)

--- a/test.sh
+++ b/test.sh
@@ -9,4 +9,4 @@ export DAPP_TEST_TIMESTAMP=$(seth block latest timestamp)
 export DAPP_TEST_NUMBER=$(seth block latest number)
 
 # LANG=C.UTF-8 hevm dapp-test --match "quick" --rpc="$ETH_RPC_URL" --json-file=out/dapp.sol.json --dapp-root=. --verbose 1
-LANG=C.UTF-8 hevm dapp-test --rpc="$ETH_RPC_URL" --json-file=out/dapp.sol.json --dapp-root=. --verbose 1 --match seek
+LANG=C.UTF-8 hevm dapp-test --rpc="$ETH_RPC_URL" --json-file=out/dapp.sol.json --dapp-root=. --verbose 1

--- a/test.sh
+++ b/test.sh
@@ -9,4 +9,4 @@ export DAPP_TEST_TIMESTAMP=$(seth block latest timestamp)
 export DAPP_TEST_NUMBER=$(seth block latest number)
 
 # LANG=C.UTF-8 hevm dapp-test --match "quick" --rpc="$ETH_RPC_URL" --json-file=out/dapp.sol.json --dapp-root=. --verbose 1
-LANG=C.UTF-8 hevm dapp-test --rpc="$ETH_RPC_URL" --json-file=out/dapp.sol.json --dapp-root=. --verbose 1
+LANG=C.UTF-8 hevm dapp-test --rpc="$ETH_RPC_URL" --json-file=out/dapp.sol.json --dapp-root=. --verbose 1 --match seek


### PR DESCRIPTION
Does a few things:
 - overwrites storage slots of on-chain contracts that are pulled in with fixed values to allow for repeatable tests that aren't broken by mainnet state evolution
 - improves the testing for `seek`
 - gas optimizes the implementation of `seek`; this makes `seek` about 1.6% cheaper

There's a lot more that can be done on the tests now that they're deterministic, but I think the diff here is big enough for one PR.