### PR TITLE
CVF-43: Remove change() function

### DIFF
--- a/src/Univ2LpOracle.sol
+++ b/src/Univ2LpOracle.sol
@@ -89,7 +89,7 @@ contract UNIV2LPOracle {
         _;
     }
 
-    address public src;             // Price source
+    address public immutable src;   // Price source
     uint16  public hop = 1 hours;   // Minimum time inbetween price updates
     uint64  public zzz;             // Time of last price update
     bytes32 public immutable wat;   // Token whose price is being tracked
@@ -155,7 +155,6 @@ contract UNIV2LPOracle {
     // --- Events ---
     event Rely(address indexed usr);
     event Deny(address indexed usr);
-    event Change(address indexed src);
     event Step(uint256 hop);
     event Stop();
     event Start();
@@ -189,11 +188,6 @@ contract UNIV2LPOracle {
     function start() external auth {
         stopped = 0;
         emit Start();
-    }
-
-    function change(address _src) external auth {
-        src = _src;
-        emit Change(src);
     }
 
     function step(uint256 _hop) external auth {

--- a/src/Univ2LpOracle.t.sol
+++ b/src/Univ2LpOracle.t.sol
@@ -467,12 +467,6 @@ contract UNIV2LPOracleTest is DSTest {
         assertTrue(nxtVal > 0);                                      // Verify queued oracle value
     }
 
-    function test_change() public {
-        assertEq(daiEthLPOracle.src(), DAI_ETH_UNI_POOL);            // Verify source is DAI-ETH pool
-        daiEthLPOracle.change(WBTC_ETH_UNI_POOL);                    // Change source to WBTC-ETH pool
-        assertEq(daiEthLPOracle.src(), WBTC_ETH_UNI_POOL);           // Verify source is WBTC-ETH pool
-    }
-
     function test_pass() public {
         assertTrue(daiEthLPOracle.pass());                           // Verify time interval `hop`has elapsed
         daiEthLPOracle.poke();                                       // Poke oracle


### PR DESCRIPTION
Addresses AVDK CVF-43

Remove the ability to `change()` the `src`. Also makes the `src` immutable for gas savings. 

Changing the `src` contract does not re-normalize the `normalizerX` variables, so it's possible to get into a situation where the src token decimals don't match expected values, and there's no extra validation.

Simplest solution here is to remove `src` modifier and make calls to it more efficient by making it `immutable`. If the src needs to be changed the oracle can be re-deployed.