### PR TITLE
emit rely event in the constructor

### DIFF
--- a/src/Univ2LpOracle.sol
+++ b/src/Univ2LpOracle.sol
@@ -169,6 +169,7 @@ contract UNIV2LPOracle {
         require(_src  != address(0),                        "UNIV2LPOracle/invalid-src-address");
         require(_orb0 != address(0) && _orb1 != address(0), "UNIV2LPOracle/invalid-oracle-address");
         wards[msg.sender] = 1;
+        emit Rely(msg.sender);
         src  = _src;
         zzz  = 0;
         wat  = _wat;


### PR DESCRIPTION
This is important to make sure the deployer isn't relied. Finding the deployer address without an event is hard. Right now, `dss-ward` is using Etherscan's centralized API to find the deployment transaction, and even then the search is non-trivial.