### PR TITLE
CVF-54: remove timestamp return from seek()

### DIFF
--- a/src/Univ2LpOracle.sol
+++ b/src/Univ2LpOracle.sol
@@ -251,10 +251,10 @@ contract UNIV2LPOracle {
 
     function poke() external stoppable {
         require(pass(), "UNIV2LPOracle/not-passed");
-        uint val = seek();
+        uint128 val = seek();
         require(val != 0, "UNIV2LPOracle/invalid-price");
         cur = nxt;
-        nxt = Feed(uint128(val), 1);
+        nxt = Feed(val, 1);
         zzz = uint64(block.timestamp);
         emit Value(cur.val, nxt.val);
     }

--- a/src/Univ2LpOracle.sol
+++ b/src/Univ2LpOracle.sol
@@ -216,14 +216,13 @@ contract UNIV2LPOracle {
         return block.timestamp >= add(zzz, hop);
     }
 
-    function seek() internal returns (uint128 quote, uint32 ts) {
+    function seek() internal returns (uint128 quote) {
         // Sync up reserves of uniswap liquidity pool
         UniswapV2PairLike(src).sync();
 
         // Get reserves of uniswap liquidity pool
-        (uint112 res0, uint112 res1, uint32 _ts) = UniswapV2PairLike(src).getReserves();
+        (uint112 res0, uint112 res1, uint32 ts) = UniswapV2PairLike(src).getReserves();
         require(res0 > 0 && res1 > 0, "UNIV2LPOracle/invalid-reserves");
-        ts = _ts;
         require(ts == block.timestamp);
 
         // Adjust reserves w/ respect to decimals
@@ -252,11 +251,11 @@ contract UNIV2LPOracle {
 
     function poke() external stoppable {
         require(pass(), "UNIV2LPOracle/not-passed");
-        (uint val, uint32 ts) = seek();
+        uint val = seek();
         require(val != 0, "UNIV2LPOracle/invalid-price");
         cur = nxt;
         nxt = Feed(uint128(val), 1);
-        zzz = ts;
+        zzz = uint64(block.timestamp);
         emit Value(cur.val, nxt.val);
     }
 

--- a/src/Univ2LpOracle.t.sol
+++ b/src/Univ2LpOracle.t.sol
@@ -21,7 +21,7 @@ interface OSMLike {
 contract SeekableOracle is UNIV2LPOracle {
     constructor(address _src, bytes32 _wat, address _orb0, address _orb1) public UNIV2LPOracle(_src, _wat, _orb0, _orb1) {}
 
-    function _seek() public returns (uint128 quote, uint32 ts) {
+    function _seek() public returns (uint128 quote) {
         return seek();
     }
 
@@ -310,10 +310,9 @@ contract UNIV2LPOracleTest is DSTest {
 
     function test_seek_dai() public {
         uint256 preGas = gasleft();
-        (uint128 lpTokenPrice128, uint32 zzz) = seekableOracleDAI._seek();        // Get new dai-eth lp price from uniswap
+        uint128 lpTokenPrice128 = seekableOracleDAI._seek();        // Get new dai-eth lp price from uniswap
         uint256 postGas = gasleft();
         log_named_uint("dai seek gas", preGas - postGas);
-        assertTrue(zzz > uint32(0));                                              // Verify timestamp was set
         assertTrue(lpTokenPrice128 > 0);                                          // Verify price was set
         uint256 lpTokenPrice = uint256(lpTokenPrice128);
         uint256 expectedPrice =
@@ -329,16 +328,15 @@ contract UNIV2LPOracleTest is DSTest {
 
     function test_seek_wbtc() public {
         uint256 preGas = gasleft();
-        (uint128 lpTokenPrice128, uint32 zzz) = seekableOracleWBTC._seek();       // Get new wbtc-eth lp price from uniswap
+        uint128 lpTokenPrice128 = seekableOracleWBTC._seek();       // Get new wbtc-eth lp price from uniswap
         uint256 postGas = gasleft();
         log_named_uint("wbtc seek gas", preGas - postGas);
-        assertTrue(zzz > uint32(0));                                              // Verify timestamp was set
         assertTrue(lpTokenPrice128 > 0);                                          // Verify price was set
         uint256 lpTokenPrice = uint256(lpTokenPrice128);
         uint256 expectedPrice =
             add(mul(ethPrice,  IERC20(WETH).balanceOf(WBTC_ETH_UNI_POOL)),
                 mul(wbtcPrice, IERC20(WBTC).balanceOf(WBTC_ETH_UNI_POOL) * 10**10))
-            / IERC20(WBTC_ETH_UNI_POOL).totalSupply();                             // assumes protocol fee is 0
+            / IERC20(WBTC_ETH_UNI_POOL).totalSupply();                            // assumes protocol fee is 0
         uint256 diff =
             lpTokenPrice  > expectedPrice ?
             lpTokenPrice  - expectedPrice :

--- a/src/Univ2LpOracle.t.sol
+++ b/src/Univ2LpOracle.t.sol
@@ -310,7 +310,7 @@ contract UNIV2LPOracleTest is DSTest {
 
     function test_seek_dai() public {
         uint256 preGas = gasleft();
-        uint128 lpTokenPrice128 = seekableOracleDAI._seek();        // Get new dai-eth lp price from uniswap
+        uint128 lpTokenPrice128 = seekableOracleDAI._seek();                      // Get new dai-eth lp price from uniswap
         uint256 postGas = gasleft();
         log_named_uint("dai seek gas", preGas - postGas);
         assertTrue(lpTokenPrice128 > 0);                                          // Verify price was set
@@ -328,7 +328,7 @@ contract UNIV2LPOracleTest is DSTest {
 
     function test_seek_wbtc() public {
         uint256 preGas = gasleft();
-        uint128 lpTokenPrice128 = seekableOracleWBTC._seek();       // Get new wbtc-eth lp price from uniswap
+        uint128 lpTokenPrice128 = seekableOracleWBTC._seek();                     // Get new wbtc-eth lp price from uniswap
         uint256 postGas = gasleft();
         log_named_uint("wbtc seek gas", preGas - postGas);
         assertTrue(lpTokenPrice128 > 0);                                          // Verify price was set

--- a/src/Univ2LpOracle.t.sol
+++ b/src/Univ2LpOracle.t.sol
@@ -25,11 +25,11 @@ contract SeekableOracle is UNIV2LPOracle {
         return seek();
     }
 
-    function _cur() public returns (uint128 val, uint128 has) {
+    function _cur() public view returns (uint128 val, uint128 has) {
         return (cur.val, cur.has);
     }
 
-    function _nxt() public returns (uint128 val, uint128 has) {
+    function _nxt() public view returns (uint128 val, uint128 has) {
         return (nxt.val, nxt.has);
     }
 }


### PR DESCRIPTION
Fixes CVF-54, and obsoletes CVF-52.