### PR TITLE
CVF-13: Index some creation parameters

### DIFF
--- a/src/UNIV2LPOracle.sol
+++ b/src/UNIV2LPOracle.sol
@@ -71,7 +71,7 @@ contract UNIV2LPOracleFactory {
 
     mapping(address => bool) public isOracle;
 
-    event NewUNIV2LPOracle(address sender, address orcl, bytes32 wat, address tok0, address tok1, address orb0, address orb1);
+    event NewUNIV2LPOracle(address sender, address orcl, bytes32 wat, address indexed tok0, address indexed tok1, address orb0, address orb1);
 
     // Create new Uniswap V2 LP Token Oracle instance
     function build(address _src, bytes32 _wat, address _orb0, address _orb1) public returns (address orcl) {

--- a/src/UNIV2LPOracle.t.sol
+++ b/src/UNIV2LPOracle.t.sol
@@ -331,7 +331,7 @@ contract UNIV2LPOracleTest is DSTest {
 
     // Passed 10 rounds of fuzzing with 10,000 test cases
     function test_compare_sqrt(uint256 exp) public {
-        if (exp == 0 ) return;
+        if (exp == 0) return;
 
         // Convert to WAD since that is what we operate on
         if (exp < MAX_WAD_VAL) {

--- a/src/UNIV2LPOracle.t.sol
+++ b/src/UNIV2LPOracle.t.sol
@@ -331,7 +331,9 @@ contract UNIV2LPOracleTest is DSTest {
 
     // Passed 10 rounds of fuzzing with 10,000 test cases
     function test_compare_sqrt(uint256 exp) public {
-            // Convert to WAD since that is what we operate on
+        if (exp == 0 ) return;
+
+        // Convert to WAD since that is what we operate on
         if (exp < MAX_WAD_VAL) {
             exp = mul(exp, WAD);
         }


### PR DESCRIPTION
IMO `tok0` and `tok1` make the most sense to index, although I could possibly see an argument for `sender`--but I generally expect that to be low cardinality, unless other teams besides Maker start using this exact same oracle code. I don't think `orcl` is very interesting to index if `tok0` and `tok1` are indexed. `orb0` and `orb1` are probably more interesting to have as data to check if they are what is expected based on `tok0` and `tok1`. I think indexing `wat` likely becomes redundant as well if `tok0` and `tok1` are indexed.