### PR TITLE
CVF-50, CVF-22: storage packing and other gas optimizations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,7 @@
-all    :; dapp --use solc:0.6.12 build
+.PHONY: build
+
+all    :  build;
+build  :; DAPP_BUILD_OPTIMIZE=1 DAPP_BUILD_OPTIMIZE_RUNS=0 dapp --use solc:0.6.12 build
 clean  :; dapp clean
 test   :; ./test.sh
 deploy :; dapp create Univ2LpOracle

--- a/Makefile
+++ b/Makefile
@@ -3,5 +3,5 @@
 all    :  build;
 build  :; DAPP_BUILD_OPTIMIZE=1 DAPP_BUILD_OPTIMIZE_RUNS=0 dapp --use solc:0.6.12 build
 clean  :; dapp clean
-test   :; ./test.sh
+test   :; ./test.sh $(MATCH)
 deploy :; dapp create Univ2LpOracle

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: build
 
 all    :  build;
-build  :; DAPP_BUILD_OPTIMIZE=1 DAPP_BUILD_OPTIMIZE_RUNS=0 dapp --use solc:0.6.12 build
+build  :; DAPP_BUILD_OPTIMIZE=1 DAPP_BUILD_OPTIMIZE_RUNS=200 dapp --use solc:0.6.12 build
 clean  :; dapp clean
 test   :; ./test.sh $(MATCH)
 deploy :; dapp create Univ2LpOracle

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: build
 
 all    :  build;
-build  :; DAPP_BUILD_OPTIMIZE=1 DAPP_BUILD_OPTIMIZE_RUNS=200 dapp --use solc:0.6.12 build
+build  :; ./build.sh
 clean  :; dapp clean
 test   :; ./test.sh $(MATCH)
 deploy :; dapp create Univ2LpOracle

--- a/build.sh
+++ b/build.sh
@@ -23,4 +23,4 @@ if [ ${MAJOR} = 0 ]; then
     fi
 fi
 
-DAPP_BUILD_OPTIMIZE=1 DAPP_BUILD_OPTIMIZE_RUNS=100000 dapp --use solc:0.6.12 build
+DAPP_BUILD_OPTIMIZE=1 DAPP_BUILD_OPTIMIZE_RUNS=200 dapp --use solc:0.6.12 build

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+VERSION_STRING=$(dapp --version | grep dapp)
+oIFS=${IFS}
+IFS=' '
+read -a ARR <<<${VERSION_STRING}
+DAPP_VERSION=${ARR[1]}
+IFS='.'
+read -a ARR <<<${DAPP_VERSION}
+IFS=${oIFS}
+MAJOR=${ARR[0]}
+MINOR=${ARR[1]}
+PATCH=${ARR[2]}
+
+if [ ${MAJOR} = 0 ]; then
+    if [ ${MINOR} -lt 32 ]; then
+        echo "Incompatible dapp version; must use at least 0.32.2"
+        exit 1
+    fi
+    if [ ${PATCH} -lt 2 ]; then
+        echo "Incompatible dapp version; must use at least 0.32.2"
+        exit 1
+    fi
+fi
+
+DAPP_BUILD_OPTIMIZE=1 DAPP_BUILD_OPTIMIZE_RUNS=100000 dapp --use solc:0.6.12 build

--- a/build.sh
+++ b/build.sh
@@ -17,7 +17,7 @@ if [ ${MAJOR} = 0 ]; then
         echo "Incompatible dapp version; must use at least 0.32.2"
         exit 1
     fi
-    if [ ${PATCH} -lt 2 ]; then
+    if [ ${MINOR} = 32 ] && [ ${PATCH} -lt 2 ]; then
         echo "Incompatible dapp version; must use at least 0.32.2"
         exit 1
     fi

--- a/src/UNIV2LPOracle.sol
+++ b/src/UNIV2LPOracle.sol
@@ -290,18 +290,20 @@ contract UNIV2LPOracle {
     function poke() external {
 
         // Ensure a single SLOAD while avoiding solc's excessive bitmasking bureaucracy.
-        uint256 _stopped;
-        uint256 _hop;
         uint256 _zph;
-        assembly {
-            _zph     := sload(1)
-            _stopped := and(_zph,          0xffff)
-            _hop     := and(shr(16, _zph), 0xffff)
-            _zph     := shr(32, _zph)
-        }
+        uint256 _hop;
+        {
+            uint256 _stopped;  // block-scoping _stopped here saves a little gas
+            assembly {
+                _zph     := sload(1)
+                _stopped := and(_zph,          0xffff)
+                _hop     := and(shr(16, _zph), 0xffff)
+                _zph     := shr(32, _zph)
+            }
 
-        // When stopped, values are set to zero and should remain such; thus, disallow updating in that case.
-        require(_stopped == 0, "UNIV2LPOracle/is-stopped");
+            // When stopped, values are set to zero and should remain such; thus, disallow updating in that case.
+            require(_stopped == 0, "UNIV2LPOracle/is-stopped");
+        }
 
         // Equivalent to requiring that pass() returns true;
         // code has been duplicated to reduce gas costs.

--- a/src/UNIV2LPOracle.sol
+++ b/src/UNIV2LPOracle.sol
@@ -247,6 +247,8 @@ contract UNIV2LPOracle {
         //   1) we return immediately,
         //   2) EVM memory is call-local, and
         //   3) pass() is an external function.
+        //
+        // Returning immediately is fine since there are no postfix modifiers to execute.
         assembly {
             let ok :=
                 iszero(
@@ -343,6 +345,11 @@ contract UNIV2LPOracle {
 
         // Equivalent to emitting Value(cur.val, nxt.val), but averts two extra SLOADs.
         emit Value(_cur.val, _val);
+
+        // Safe to terminate immediately since no postfix modifiers are applied.
+        assembly {
+            stop()
+        }
     }
 
     function peek() external view toll returns (bytes32,bool) {

--- a/src/UNIV2LPOracle.sol
+++ b/src/UNIV2LPOracle.sol
@@ -309,19 +309,16 @@ contract UNIV2LPOracle {
             sstore(
                 1,
                 add(
-                    shl(                          // zph value starts 24 bits in
-                        24,
-                        add(timestamp(), _hop)
-                    ),
-                    shl(                          // hop value starts 8 bits in
-                        8,
-                        _hop
-                    )
+                    // zph value starts 24 bits in
+                    shl(24, add(timestamp(), _hop)),
+
+                    // hop value starts 8 bits in
+                    shl(8, _hop)
                 )
             )
         }
 
-        // Equivalent to emitting Value(cur.val, nxt.val), but averts two extra SLOADs.
+        // Equivalent to emitting Value(cur.val, nxt.val), but averts extra SLOADs.
         emit Value(_cur.val, _val);
 
         // Safe to terminate immediately since no postfix modifiers are applied.

--- a/src/UNIV2LPOracle.sol
+++ b/src/UNIV2LPOracle.sol
@@ -214,7 +214,7 @@ contract UNIV2LPOracle {
     function step(uint256 _hop) external auth {
         require(_hop <= uint24(-1), "UNIV2LPOracle/invalid-hop");
         hop = uint24(_hop);
-        emit Step(hop);
+        emit Step(_hop);
     }
 
     function link(uint256 id, address orb) external auth {

--- a/src/UNIV2LPOracle.sol
+++ b/src/UNIV2LPOracle.sol
@@ -295,8 +295,8 @@ contract UNIV2LPOracle {
         cur = _cur;
         nxt = Feed(val, 1);
 
-        // Even if _hop = (2^16 - 1), the maximum possible value, this will not overflow for
-        // many, many years.
+        // Even if _hop = (2^16 - 1), the maximum possible value, this will not overflow
+        // (even a 224 bit value) for a very long time.
         _zph = block.timestamp + _hop;
 
         // Just assigning to zph will do another SLOAD by default; avoid this.

--- a/src/UNIV2LPOracle.sol
+++ b/src/UNIV2LPOracle.sol
@@ -243,7 +243,7 @@ contract UNIV2LPOracle {
         //
         // since "x >= y" is equivalent to "!(x < y)".
         //
-        // Stomping on memory slot zero is safe since
+        // Overwriting memory slot zero is safe since
         //   1) we return immediately,
         //   2) EVM memory is call-local, and
         //   3) pass() is an external function.

--- a/src/UNIV2LPOracle.sol
+++ b/src/UNIV2LPOracle.sol
@@ -297,10 +297,10 @@ contract UNIV2LPOracle {
         {
             uint256 _stopped;  // block-scoping _stopped here saves a little gas
             assembly {
-                _zph     := sload(1)
-                _stopped := and(_zph,         0xff    )
-                _hop     := and(shr(8, _zph), 0xffffff)
-                _zph     := shr(32, _zph)
+                let _slot1 := sload(1)
+                _stopped   := and(_slot1,         0xff    )
+                _hop       := and(shr(8, _slot1), 0xffffff)
+                _zph       := shr(32, _slot1)
             }
 
             // When stopped, values are set to zero and should remain such; thus, disallow updating in that case.

--- a/src/UNIV2LPOracle.sol
+++ b/src/UNIV2LPOracle.sol
@@ -241,7 +241,7 @@ contract UNIV2LPOracle {
         //
         //     return block.timestamp >= zph;
         //
-        // since "x >= y" is equivalent to "!(y < x)".
+        // since "x >= y" is equivalent to "!(x < y)".
         //
         // Stomping on memory slot zero is safe since
         //   1) we return immediately,

--- a/src/UNIV2LPOracle.sol
+++ b/src/UNIV2LPOracle.sol
@@ -325,7 +325,7 @@ contract UNIV2LPOracle {
         // but ensures no extra SLOADs are performed.
         //
         // Even if _hop = (2^16 - 1), the maximum possible value, add(timestamp(), _hop)
-        // will not overflow (even a 224 bit value) for a very long time.
+        // will not overflow (even a 232 bit value) for a very long time.
         //
         // Also, we know stopped was zero, so there is no need to account for it explicitly here.
         assembly {

--- a/src/UNIV2LPOracle.sol
+++ b/src/UNIV2LPOracle.sol
@@ -140,6 +140,9 @@ contract UNIV2LPOracle {
     function add(uint x, uint y) internal pure returns (uint z) {
         require((z = x + y) >= x, "ds-math-add-overflow");
     }
+    function sub(uint x, uint y) internal pure returns (uint z) {
+        require((z = x - y) <= x, "ds-math-sub-underflow");
+    }
     function mul(uint x, uint y) internal pure returns (uint z) {
         require(y == 0 || (z = x * y) / y == x, "ds-math-mul-overflow");
     }

--- a/src/UNIV2LPOracle.sol
+++ b/src/UNIV2LPOracle.sol
@@ -235,31 +235,8 @@ contract UNIV2LPOracle {
         return sub(zph, hop);
     }
 
-    function pass() external view returns (bool /*ok*/) {
-
-        // The below is equivalent to:
-        //
-        //     return block.timestamp >= zph;
-        //
-        // since "x >= y" is equivalent to "!(x < y)".
-        //
-        // Overwriting memory slot zero is safe since
-        //   1) we return immediately,
-        //   2) EVM memory is call-local, and
-        //   3) pass() is an external function.
-        //
-        // Returning immediately is fine since there are no postfix modifiers to execute.
-        assembly {
-            let ok :=
-                iszero(
-                    lt(
-                        timestamp(),
-                        shr(24, sload(1))  // zph
-                    )
-                )
-            mstore(0, ok)
-            return(0, 0x20)
-        }
+    function pass() external view returns (bool) {
+        return block.timestamp >= zph;
     }
 
     function seek() internal returns (uint128 quote) {

--- a/src/UNIV2LPOracle.sol
+++ b/src/UNIV2LPOracle.sol
@@ -303,7 +303,8 @@ contract UNIV2LPOracle {
         // When stopped, values are set to zero and should remain such; thus, disallow updating in that case.
         require(_stopped == 0, "UNIV2LPOracle/is-stopped");
 
-        // Equivalent to calling pass(); code has been duplicated to reduce gas costs.
+        // Equivalent to requiring that pass() returns true;
+        // code has been duplicated to reduce gas costs.
         require(block.timestamp >= _zph, "UNIV2LPOracle/not-passed");
 
         uint128 val = seek();

--- a/src/UNIV2LPOracle.sol
+++ b/src/UNIV2LPOracle.sol
@@ -322,7 +322,7 @@ contract UNIV2LPOracle {
         // Even if _hop = (2^16 - 1), the maximum possible value, add(timestamp(), _hop)
         // will not overflow (even a 224 bit value) for a very long time.
         //
-        // Also, we know stopped was zero, so ther is no need to account for it explicitly here.
+        // Also, we know stopped was zero, so there is no need to account for it explicitly here.
         assembly {
             sstore(
                 1,

--- a/src/UNIV2LPOracle.sol
+++ b/src/UNIV2LPOracle.sol
@@ -307,8 +307,9 @@ contract UNIV2LPOracle {
             require(_stopped == 0, "UNIV2LPOracle/is-stopped");
         }
 
-        // Equivalent to requiring that pass() returns true;
-        // code has been duplicated to reduce gas costs.
+        // Equivalent to requiring that pass() returns true.
+        // The logic is repeated instead of calling pass() to save gas
+        // (both by eliminating an internal call here, and allowing pass to be external).
         require(block.timestamp >= _zph, "UNIV2LPOracle/not-passed");
 
         uint128 _val = seek();

--- a/src/UNIV2LPOracle.sol
+++ b/src/UNIV2LPOracle.sol
@@ -317,13 +317,26 @@ contract UNIV2LPOracle {
         assembly {
 
             // The below is equivalent to:
+            //
             //    zph = block.timestamp + hop
             //
             // Even if _hop = (2^16 - 1), the maximum possible value, add(timestamp(), _hop)
             // will not overflow (even a 224 bit value) for a very long time.
             //
             // Also, we know stopped was zero, so ther is no need to account for it explicitly here.
-            sstore(1, add(shl(32, add(timestamp(), _hop)), shl(16, _hop)))
+            sstore(
+                1,
+                add(
+                    shl(                          // zph value starts 32 bits in
+                        32,
+                        add(timestamp(), _hop)
+                    ),
+                    shl(                          // hop value starts 16 bits in
+                        16,
+                        _hop
+                    )
+                )
+            )
         }
 
         // Equivalent to emitting Value(cur.val, nxt.val), but averts two extra SLOADs.

--- a/src/UNIV2LPOracle.t.sol
+++ b/src/UNIV2LPOracle.t.sol
@@ -564,7 +564,7 @@ contract UNIV2LPOracleTest is DSTest {
             daiEthLPOracle.poke();
         }
         diffGas = preGas - gasleft();
-        assertTrue(diffGas <= 88428);  // Will need updated for the Berlin hardfork
+        assertTrue(diffGas <= 88425);  // Will need to be updated for the Berlin hardfork.
         log_named_uint("pass+poke gas", diffGas);
 
         require(!daiEthLPOracle.pass());
@@ -574,7 +574,7 @@ contract UNIV2LPOracleTest is DSTest {
             daiEthLPOracle.poke();
         }
         diffGas = preGas - gasleft();
-        assertTrue(diffGas <= 3465);  // Will need updated for the Berlin hardfork
+        assertTrue(diffGas <= 3465);  // Will need to be updated for the Berlin hardfork.
         log_named_uint("pass-only gas", diffGas);
     }
 

--- a/src/UNIV2LPOracle.t.sol
+++ b/src/UNIV2LPOracle.t.sol
@@ -289,7 +289,7 @@ contract UNIV2LPOracleTest is DSTest {
         assertEq(oracle.src(), DAI_ETH_UNI_POOL);           // Verify uni pool is source
         assertEq(oracle.orb0(), WBTC_ORACLE);               // Verify oracle configured correctly
         assertEq(oracle.orb1(), ETH_ORACLE);                // Verify oracle configured correctly
-        assertEq(oracle.stopped(), 0);                      // Verify contract is active
+        assertEq(uint256(oracle.stopped()), 0);             // Verify contract is active
         assertTrue(factory.isOracle(address(oracle)));      // Verify factory recorded oracle
     }
 
@@ -368,7 +368,7 @@ contract UNIV2LPOracleTest is DSTest {
         assertEq(daiEthLPOracle.orb0(), USDC_ORACLE);      // Verify token 0 oracle is USDC oracle
         assertEq(daiEthLPOracle.orb1(), ETH_ORACLE);       // Verify token 1 oracle is ETH oracle
         assertEq(daiEthLPOracle.wards(address(this)), 1);  // Verify owner
-        assertEq(daiEthLPOracle.stopped(), 0);             // Verify contract active
+        assertEq(uint256(daiEthLPOracle.stopped()), 0);    // Verify contract active
     }
 
     function test_seek_dai() public {

--- a/src/UNIV2LPOracle.t.sol
+++ b/src/UNIV2LPOracle.t.sol
@@ -566,7 +566,7 @@ contract UNIV2LPOracleTest is DSTest {
         daiEthLPOracle.pass();
         daiEthLPOracle.poke();
         diffGas = preGas - gasleft();
-        assertTrue(diffGas <= 88375);  // Will need to be updated for the Berlin hardfork.
+        assertTrue(diffGas <= 88449);  // Will need to be updated for the Berlin hardfork.
         log_named_uint("pass+poke gas", diffGas);
 
         require(!daiEthLPOracle.pass());

--- a/src/UNIV2LPOracle.t.sol
+++ b/src/UNIV2LPOracle.t.sol
@@ -564,7 +564,7 @@ contract UNIV2LPOracleTest is DSTest {
             daiEthLPOracle.poke();
         }
         diffGas = preGas - gasleft();
-        assertTrue(diffGas <= 88425);  // Will need to be updated for the Berlin hardfork.
+        assertTrue(diffGas <= 88408);  // Will need to be updated for the Berlin hardfork.
         log_named_uint("pass+poke gas", diffGas);
 
         require(!daiEthLPOracle.pass());

--- a/src/UNIV2LPOracle.t.sol
+++ b/src/UNIV2LPOracle.t.sol
@@ -580,7 +580,7 @@ contract UNIV2LPOracleTest is DSTest {
         uint256 preGas = gasleft();
         daiEthLPOracle.poke();
         uint256 diffGas = preGas - gasleft();
-        assertTrue(diffGas <= 85027);  // Will need to be updated for the Berlin hardfork.
+        assertTrue(diffGas <= 85058);  // Will need to be updated for the Berlin hardfork.
         log_named_uint("poke gas", diffGas);
     }
 

--- a/src/UNIV2LPOracle.t.sol
+++ b/src/UNIV2LPOracle.t.sol
@@ -558,7 +558,7 @@ contract UNIV2LPOracleTest is DSTest {
         uint256 preGas = gasleft();
         daiEthLPOracle.poke();
         uint256 diffGas = preGas - gasleft();
-        assertTrue(diffGas <= 85058);  // Will need to be updated after the Berlin hardfork.
+        assertTrue(diffGas <= 84625);  // Will need to be updated after the Berlin hardfork.
         log_named_uint("poke gas", diffGas);
     }
 

--- a/src/UNIV2LPOracle.t.sol
+++ b/src/UNIV2LPOracle.t.sol
@@ -551,34 +551,37 @@ contract UNIV2LPOracleTest is DSTest {
         assertTrue(daiEthLPOracle.pass());                           // Fail pass
     }
 
-    // This test examines the gas costs of a common pattern which needs
-    // to be maximally gas-optimized.
-    function test_gas_pass_poke() public {
+    function test_gas_pass() public {
         uint256 preGas;
         uint256 diffGas;
 
         require(daiEthLPOracle.pass());
 
-        // Run the affected parts of the common
-        //   if (orcl.pass()) orcl.poke();
-        // pattern for the case pass() returns true.
-        preGas = gasleft();
-        daiEthLPOracle.pass();
-        daiEthLPOracle.poke();
-        diffGas = preGas - gasleft();
-        assertTrue(diffGas <= 88449);  // Will need to be updated for the Berlin hardfork.
-        log_named_uint("pass+poke gas", diffGas);
-
-        require(!daiEthLPOracle.pass());
-
-        // Run the affected parts of the common
-        //   if (orcl.pass()) orcl.poke();
-        // pattern for the case pass() returns false.
         preGas = gasleft();
         daiEthLPOracle.pass();
         diffGas = preGas - gasleft();
         assertTrue(diffGas <= 3447);  // Will need to be updated for the Berlin hardfork.
-        log_named_uint("pass-only gas", diffGas);
+        log_named_uint("pass true gas", diffGas);
+
+        daiEthLPOracle.poke();
+        require(!daiEthLPOracle.pass());
+
+        preGas = gasleft();
+        daiEthLPOracle.pass();
+        diffGas = preGas - gasleft();
+        assertTrue(diffGas <= 3447);  // Will need to be updated for the Berlin hardfork.
+        log_named_uint("pass false gas", diffGas);
+    }
+
+    // Most critical function to minimize the gas costs of since it's called frequently and must succeed.
+    function test_gas_poke() public {
+        require(daiEthLPOracle.pass());
+
+        uint256 preGas = gasleft();
+        daiEthLPOracle.poke();
+        uint256 diffGas = preGas - gasleft();
+        assertTrue(diffGas <= 85027);  // Will need to be updated for the Berlin hardfork.
+        log_named_uint("poke gas", diffGas);
     }
 
     function testFail_whitelist_peep() public {

--- a/src/UNIV2LPOracle.t.sol
+++ b/src/UNIV2LPOracle.t.sol
@@ -559,22 +559,25 @@ contract UNIV2LPOracleTest is DSTest {
 
         require(daiEthLPOracle.pass());
 
+        // Run the affected parts of the common
+        //   if (orcl.pass()) orcl.poke();
+        // pattern for the case pass() returns true.
         preGas = gasleft();
-        if (daiEthLPOracle.pass()) {
-            daiEthLPOracle.poke();
-        }
+        daiEthLPOracle.pass();
+        daiEthLPOracle.poke();
         diffGas = preGas - gasleft();
-        assertTrue(diffGas <= 88408);  // Will need to be updated for the Berlin hardfork.
+        assertTrue(diffGas <= 88375);  // Will need to be updated for the Berlin hardfork.
         log_named_uint("pass+poke gas", diffGas);
 
         require(!daiEthLPOracle.pass());
 
+        // Run the affected parts of the common
+        //   if (orcl.pass()) orcl.poke();
+        // pattern for the case pass() returns false.
         preGas = gasleft();
-        if (daiEthLPOracle.pass()) {
-            daiEthLPOracle.poke();
-        }
+        daiEthLPOracle.pass();
         diffGas = preGas - gasleft();
-        assertTrue(diffGas <= 3465);  // Will need to be updated for the Berlin hardfork.
+        assertTrue(diffGas <= 3447);  // Will need to be updated for the Berlin hardfork.
         log_named_uint("pass-only gas", diffGas);
     }
 

--- a/src/UNIV2LPOracle.t.sol
+++ b/src/UNIV2LPOracle.t.sol
@@ -551,36 +551,14 @@ contract UNIV2LPOracleTest is DSTest {
         assertTrue(daiEthLPOracle.pass());                           // Fail pass
     }
 
-    function test_gas_pass() public {
-        uint256 preGas;
-        uint256 diffGas;
-
-        require(daiEthLPOracle.pass());
-
-        preGas = gasleft();
-        daiEthLPOracle.pass();
-        diffGas = preGas - gasleft();
-        assertTrue(diffGas <= 3447);  // Will need to be updated for the Berlin hardfork.
-        log_named_uint("pass true gas", diffGas);
-
-        daiEthLPOracle.poke();
-        require(!daiEthLPOracle.pass());
-
-        preGas = gasleft();
-        daiEthLPOracle.pass();
-        diffGas = preGas - gasleft();
-        assertTrue(diffGas <= 3447);  // Will need to be updated for the Berlin hardfork.
-        log_named_uint("pass false gas", diffGas);
-    }
-
-    // Most critical function to minimize the gas costs of since it's called frequently and must succeed.
+    // Most critical function to minimize the gas costs of since it must be successfully executed frequently.
     function test_gas_poke() public {
         require(daiEthLPOracle.pass());
 
         uint256 preGas = gasleft();
         daiEthLPOracle.poke();
         uint256 diffGas = preGas - gasleft();
-        assertTrue(diffGas <= 85058);  // Will need to be updated for the Berlin hardfork.
+        assertTrue(diffGas <= 85058);  // Will need to be updated after the Berlin hardfork.
         log_named_uint("poke gas", diffGas);
     }
 

--- a/src/UNIV2LPOracle.t.sol
+++ b/src/UNIV2LPOracle.t.sol
@@ -555,7 +555,7 @@ contract UNIV2LPOracleTest is DSTest {
     // to be maximally gas-optimized.
     function test_gas_pass_poke() public {
         uint256 preGas;
-        uint256 postGas;
+        uint256 diffGas;
 
         require(daiEthLPOracle.pass());
 
@@ -563,8 +563,9 @@ contract UNIV2LPOracleTest is DSTest {
         if (daiEthLPOracle.pass()) {
             daiEthLPOracle.poke();
         }
-        postGas = gasleft();
-        log_named_uint("pass+poke gas", preGas - postGas);
+        diffGas = preGas - gasleft();
+        assertTrue(diffGas <= 88428);  // Will need updated for the Berlin hardfork
+        log_named_uint("pass+poke gas", diffGas);
 
         require(!daiEthLPOracle.pass());
 
@@ -572,8 +573,9 @@ contract UNIV2LPOracleTest is DSTest {
         if (daiEthLPOracle.pass()) {
             daiEthLPOracle.poke();
         }
-        postGas = gasleft();
-        log_named_uint("pass-only gas", preGas - postGas);
+        diffGas = preGas - gasleft();
+        assertTrue(diffGas <= 3465);  // Will need updated for the Berlin hardfork
+        log_named_uint("pass-only gas", diffGas);
     }
 
     function testFail_whitelist_peep() public {

--- a/test.sh
+++ b/test.sh
@@ -10,3 +10,5 @@ export DAPP_TEST_NUMBER=$(seth block latest number)
 
 # LANG=C.UTF-8 hevm dapp-test --match "quick" --rpc="$ETH_RPC_URL" --json-file=out/dapp.sol.json --dapp-root=. --verbose 1
 LANG=C.UTF-8 hevm dapp-test --rpc="$ETH_RPC_URL" --json-file=out/dapp.sol.json --dapp-root=. --verbose 1
+#LANG=C.UTF-8 hevm dapp-test --rpc="$ETH_RPC_URL" --json-file=out/dapp.sol.json --dapp-root=. --verbose 1 --debug
+#LANG=C.UTF-8 hevm dapp-test --rpc="$ETH_RPC_URL" --json-file=out/dapp.sol.json --dapp-root=. --verbose 2 --match test_gas_pass_poke

--- a/test.sh
+++ b/test.sh
@@ -8,7 +8,7 @@ make build
 export DAPP_TEST_TIMESTAMP=$(seth block latest timestamp)
 export DAPP_TEST_NUMBER=$(seth block latest number)
 
-#LANG=C.UTF-8 hevm dapp-test --rpc="$ETH_RPC_URL" --json-file=out/dapp.sol.json --dapp-root=. --verbose 1
+LANG=C.UTF-8 hevm dapp-test --rpc="$ETH_RPC_URL" --json-file=out/dapp.sol.json --dapp-root=. --verbose 1
 
 # Will print the gas cost of the pass-poke hot path; useful when optimizing.
-LANG=C.UTF-8 hevm dapp-test --rpc="$ETH_RPC_URL" --json-file=out/dapp.sol.json --dapp-root=. --verbose 2 --match test_gas_pass_poke
+# LANG=C.UTF-8 hevm dapp-test --rpc="$ETH_RPC_URL" --json-file=out/dapp.sol.json --dapp-root=. --verbose 2 --match test_gas_pass_poke

--- a/test.sh
+++ b/test.sh
@@ -3,7 +3,7 @@ set -e
 
 [[ "$ETH_RPC_URL" && "$(seth chain)" == "ethlive"  ]] || { echo "Please set a mainnet ETH_RPC_URL"; exit 1;  }
 
-DAPP_BUILD_OPTIMIZE=1 DAPP_BUILD_OPTIMIZE_RUNS=1 dapp --use solc:0.6.12 build
+make build
 
 export DAPP_TEST_TIMESTAMP=$(seth block latest timestamp)
 export DAPP_TEST_NUMBER=$(seth block latest number)

--- a/test.sh
+++ b/test.sh
@@ -8,7 +8,10 @@ make build
 export DAPP_TEST_TIMESTAMP=$(seth block latest timestamp)
 export DAPP_TEST_NUMBER=$(seth block latest number)
 
-LANG=C.UTF-8 hevm dapp-test --rpc="$ETH_RPC_URL" --json-file=out/dapp.sol.json --dapp-root=. --verbose 1
-
-# Will print the gas cost of the pass-poke hot path; useful when optimizing.
-# LANG=C.UTF-8 hevm dapp-test --rpc="$ETH_RPC_URL" --json-file=out/dapp.sol.json --dapp-root=. --verbose 2 --match test_gas_pass_poke
+if [[ -z "$1" ]]; then
+  LANG=C.UTF-8 hevm dapp-test --rpc="$ETH_RPC_URL" --json-file=out/dapp.sol.json --dapp-root=. --verbose 1
+else
+  # If running with make test, one can trigger this logic via:
+  # $ MATCH=some_string_to_match make test
+  LANG=C.UTF-8 hevm dapp-test --rpc="$ETH_RPC_URL" --json-file=out/dapp.sol.json --dapp-root=. --verbose 2 --match "$1"
+fi

--- a/test.sh
+++ b/test.sh
@@ -8,7 +8,7 @@ make build
 export DAPP_TEST_TIMESTAMP=$(seth block latest timestamp)
 export DAPP_TEST_NUMBER=$(seth block latest number)
 
-# LANG=C.UTF-8 hevm dapp-test --match "quick" --rpc="$ETH_RPC_URL" --json-file=out/dapp.sol.json --dapp-root=. --verbose 1
 LANG=C.UTF-8 hevm dapp-test --rpc="$ETH_RPC_URL" --json-file=out/dapp.sol.json --dapp-root=. --verbose 1
-#LANG=C.UTF-8 hevm dapp-test --rpc="$ETH_RPC_URL" --json-file=out/dapp.sol.json --dapp-root=. --verbose 1 --debug
-#LANG=C.UTF-8 hevm dapp-test --rpc="$ETH_RPC_URL" --json-file=out/dapp.sol.json --dapp-root=. --verbose 2 --match test_gas_pass_poke
+
+# Will print the gas cost of the pass-poke hot path; useful when optimizing.
+# LANG=C.UTF-8 hevm dapp-test --rpc="$ETH_RPC_URL" --json-file=out/dapp.sol.json --dapp-root=. --verbose 2 --match test_gas_pass_poke

--- a/test.sh
+++ b/test.sh
@@ -8,7 +8,7 @@ make build
 export DAPP_TEST_TIMESTAMP=$(seth block latest timestamp)
 export DAPP_TEST_NUMBER=$(seth block latest number)
 
-LANG=C.UTF-8 hevm dapp-test --rpc="$ETH_RPC_URL" --json-file=out/dapp.sol.json --dapp-root=. --verbose 1
+#LANG=C.UTF-8 hevm dapp-test --rpc="$ETH_RPC_URL" --json-file=out/dapp.sol.json --dapp-root=. --verbose 1
 
 # Will print the gas cost of the pass-poke hot path; useful when optimizing.
-# LANG=C.UTF-8 hevm dapp-test --rpc="$ETH_RPC_URL" --json-file=out/dapp.sol.json --dapp-root=. --verbose 2 --match test_gas_pass_poke
+LANG=C.UTF-8 hevm dapp-test --rpc="$ETH_RPC_URL" --json-file=out/dapp.sol.json --dapp-root=. --verbose 2 --match test_gas_pass_poke


### PR DESCRIPTION
This PR is somewhat non-trivial and should therefore get at least two SC team member approvals.

Versus the diffbase, the gas cost of the `if (orcl.pass()) orcl.poke;` hot path is reduced by 1632 units under the Istanbul gas schedule. This may not seem like a huge amount (the overall cost for the operation is around 90K gas), but it should be worthwhile because:
1. this adds up over time as there will be multiple copies of this contract being called hourly;
2. this PR eliminates at least 2 `SLOAD` operations--the Berlin hardfork increases the cost of `SLOAD` from 800 to 2100, so after Berlin, the savings is actually significantly greater, and `SLOAD` costs could increase even more in the future;
3. the average dollar cost of block space (determined by ETH's USD value and the gas price) is unlikely to decrease but likely to increase based on historical precedent; and,
4. oracles are critical infrastructure that must work even under conditions of extreme network congestion--even a few hundred gas might be the difference between getting an update through in a timely fashion and negatively affecting all dependent contracts due to stale data.

I believe the `Feed` structure will be touched by future PRs focused on numerical improvements (particularly increasing the number of bits in the price value), so I have held off on doing any optimizations that rely on the details of that structure.