### PR TITLE
CVF-58: Fix unsafe cast to uint128

### DIFF
--- a/src/UNIV2LPOracle.sol
+++ b/src/UNIV2LPOracle.sol
@@ -252,10 +252,11 @@ contract UNIV2LPOracle {
         uint256 supply = ERC20Like(src).totalSupply();
 
         // No need to check that the supply is nonzero, Solidity reverts on division by zero.
-        quote = uint128(
-                mul(2 * WAD, sqrt(wmul(k, wmul(val0, val1))))
-                    / supply
-        );
+        uint256 preq =  mul(2 * WAD, sqrt(wmul(k, wmul(val0, val1))))
+                    / supply;
+
+        require(preq <= ((2 ** 128) - 1), "UNIV2LPOracle/quote-overflow");
+        quote = uint128(preq);
     }
 
     function poke() external stoppable {

--- a/src/UNIV2LPOracle.sol
+++ b/src/UNIV2LPOracle.sol
@@ -238,8 +238,6 @@ contract UNIV2LPOracle {
         require(res0 > 0 && res1 > 0, "UNIV2LPOracle/invalid-reserves");
         require(ts == block.timestamp);
 
-        
-
         // Calculate constant product invariant k (WAD * WAD)
         // Explicitly cast reserves to uint256
         uint256 k = mul(normalizer, mul(uint256(res0), uint256(res1)));

--- a/src/UNIV2LPOracle.sol
+++ b/src/UNIV2LPOracle.sol
@@ -117,7 +117,7 @@ contract UNIV2LPOracle {
     modifier stoppable { require(stopped == 0, "UNIV2LPOracle/is-stopped"); _; }
 
     // --- Data ---
-    uint256 private immutable normalizer;  // Multiplicative factor that normalizes a token pair balance to a WAD; 10^(18 - dec)
+    uint256 private immutable normalizer;  // Multiplicative factor that normalizes a token pair balance product to WAD^2; 10^(36 - dec0 - dec1)
    
 
     address public            orb0;  // Oracle for token0, ideally a Medianizer

--- a/src/UNIV2LPOracle.sol
+++ b/src/UNIV2LPOracle.sol
@@ -118,7 +118,6 @@ contract UNIV2LPOracle {
 
     // --- Data ---
     uint256 private immutable normalizer;  // Multiplicative factor that normalizes a token pair balance product to WAD^2; 10^(36 - dec0 - dec1)
-   
 
     address public            orb0;  // Oracle for token0, ideally a Medianizer
     address public            orb1;  // Oracle for token1, ideally a Medianizer

--- a/src/UNIV2LPOracle.sol
+++ b/src/UNIV2LPOracle.sol
@@ -187,7 +187,6 @@ contract UNIV2LPOracle {
         wat  = _wat;
         uint256 dec0 = uint256(ERC20Like(UniswapV2PairLike(_src).token0()).decimals());
         require(dec0 <= 18, "UNIV2LPOracle/token0-dec-gt-18");
-        
         uint256 dec1 = uint256(ERC20Like(UniswapV2PairLike(_src).token1()).decimals());
         require(dec1 <= 18, "UNIV2LPOracle/token1-dec-gt-18");
         normalizer = mul(10 ** (18 - dec1), 10 ** (18 - dec0));  // Calculate normalization factor of token1

--- a/src/UNIV2LPOracle.t.sol
+++ b/src/UNIV2LPOracle.t.sol
@@ -362,65 +362,6 @@ contract UNIV2LPOracleTest is DSTest {
         // Since we have confidence in Babylonian method, we simply check for equivalence
         assertEq(rootVal, rootAltVal);
     }
-    uint112 max112 = type(uint112).max;
-
-    function test_seek_equivalence(
-        uint8 decimals0,
-        uint8 decimals1,
-        uint112 res0,
-        uint112 res1
-    ) public {
-        uint256 dec0 = uint256(decimals0);
-        uint256 dec1 = uint256(decimals1);
-        if (dec1 > 18 || dec1 < 1) {
-            return;
-        }
-        if (dec0 > 18 || dec0 < 1) {
-            return;
-        }
-        if (res0 < 1) {
-            return;
-        }
-        if (res1 < 1) {
-            return;
-        }
-        // Save these for later
-        uint112 res00 = res0;
-        uint112 res11 = res1;
-
-
-        // Old method of calculating k uniswap invariant
-        uint256 preGas = gasleft();
-
-        uint256 normalizer0 = 10**(18 - dec0);
-        uint256 normalizer1 = 10**(18 - dec1);
-   
-        uint256 res0 = mul(uint256(res0), normalizer0);
-        uint256 res1 = mul(uint256(res1), normalizer1);
-        
-        uint256 k = mul(res0, res1);
-        uint256 postGas = gasleft();
-
-
-        uint256 gasUse1 = preGas - postGas;
-
-        // New method of calculating k uniswap invaiant.. store normalizers product
-        // prior to seek invocation
-        uint256 normalize_product = mul(normalizer0, normalizer1);
-        uint256 preGas2 = gasleft();
-        uint256 k_alt =
-            mul(normalize_product, mul(uint256(res00), uint256(res11)));
-        uint256 postGas2 = gasleft();
-        uint256 gasUse2 = preGas2 - postGas2;
-
-
-        log_named_uint("K", k);
-        log_named_uint("K_ALT", k_alt);
-
-        // Check equivalence of two calculations
-        assertEq(k, k_alt);
-        assertTrue(gasUse2 < gasUse1);
-    }
 
     function test_oracle_constructor() public {
         assertEq(daiEthLPOracle.src(), DAI_ETH_UNI_POOL);  // Verify source is DAI-ETH pool

--- a/src/UNIV2LPOracle.t.sol
+++ b/src/UNIV2LPOracle.t.sol
@@ -363,6 +363,72 @@ contract UNIV2LPOracleTest is DSTest {
         assertEq(rootVal, rootAltVal);
     }
 
+
+
+    uint112 max112 = 5192296858534827628530496329220095;
+
+    function test_seek_equivalence(
+        uint8 normalization0,
+        uint8 normalization1,
+        uint112 res0,
+        uint112 res1
+    ) public {
+        uint256 dec0 = uint256(normalization0);
+        uint256 dec1 = uint256(normalization1);
+        if (dec1 > 18 || dec1 < 1) {
+            return;
+        }
+        if (dec0 > 18 || dec0 < 1) {
+            return;
+        }
+        if (res0 < 1) {
+            return;
+        }
+        if (res1 < 1) {
+            return;
+        }
+        log_named_uint("dec0", dec0);
+        log_named_uint("dec1", dec1);
+        log_named_uint("norm0", normalization0);
+        log_named_uint("norm1", normalization1);
+
+        uint112 res00 = res0;
+        uint112 res11 = res1;
+        uint256 preGas = gasleft();
+
+        uint256 normalizer0 = 10**(18 - normalization1);
+        uint256 normalizer1 = 10**(18 - normalization0);
+        // log_named_uint("Normalizer 0", normalizer0);
+        // log_named_uint("Normalizer 1", normalizer1);
+
+        // log_named_uint("res0 uncasted", mul(res0, normalizer0));
+        // log_named_uint("max1 112 fill", max112);
+        // log_named_uint("res1 uncasted", mul(res1, normalizer1));
+
+        uint256 res0 = mul(res0, normalizer0);
+        uint256 res1 = mul(res1, normalizer1);
+
+        uint256 k = mul(res0, res1);
+
+        uint256 postGas = gasleft();
+
+        log_named_uint("res0", res0);
+        log_named_uint("res1", res1);
+
+        uint256 gasUse1 = preGas - postGas;
+        uint256 normalize_product = mul(normalizer0, normalizer1);
+        uint256 preGas2 = gasleft();
+
+        uint256 k_alt =
+            mul(normalize_product, mul(uint256(res00), uint256(res11)));
+        uint256 postGas2 = gasleft();
+        uint256 gasUse2 = preGas2 - postGas2;
+        log_named_uint("K", k);
+        log_named_uint("K_ALT", k_alt);
+        assertEq(k, k_alt);
+        assertTrue(gasUse2 < gasUse1);
+    }
+
     function test_oracle_constructor() public {
         assertEq(daiEthLPOracle.src(), DAI_ETH_UNI_POOL);  // Verify source is DAI-ETH pool
         assertEq(daiEthLPOracle.orb0(), USDC_ORACLE);      // Verify token 0 oracle is USDC oracle

--- a/src/UNIV2LPOracle.t.sol
+++ b/src/UNIV2LPOracle.t.sol
@@ -368,13 +368,13 @@ contract UNIV2LPOracleTest is DSTest {
     uint112 max112 = 5192296858534827628530496329220095;
 
     function test_seek_equivalence(
-        uint8 normalization0,
-        uint8 normalization1,
+        uint8 decimals0,
+        uint8 decimals1,
         uint112 res0,
         uint112 res1
     ) public {
-        uint256 dec0 = uint256(normalization0);
-        uint256 dec1 = uint256(normalization1);
+        uint256 dec0 = uint256(decimals0);
+        uint256 dec1 = uint256(decimals1);
         if (dec1 > 18 || dec1 < 1) {
             return;
         }
@@ -389,8 +389,8 @@ contract UNIV2LPOracleTest is DSTest {
         }
         log_named_uint("dec0", dec0);
         log_named_uint("dec1", dec1);
-        log_named_uint("norm0", normalization0);
-        log_named_uint("norm1", normalization1);
+        log_named_uint("decimals0", decimals0);
+        log_named_uint("decimals1", decimals1);
 
         uint112 res00 = res0;
         uint112 res11 = res1;
@@ -406,8 +406,8 @@ contract UNIV2LPOracleTest is DSTest {
         // log_named_uint("res1 uncasted", mul(res1, normalizer1));
         uint256 res0 = uint256(res0);
         uint256 res1 = uint256(res1);
-        if (dec0 > 1) res0 = mul(res0, dec0);
-        if (dec1 > 1) res1 = mul(res1, dec1);
+        if (normalizer0 > 1) res0 = mul(res0, normalizer0);
+        if (normalizer1 > 1) res1 = mul(res1, normalizer1);
 
         uint256 k = mul(res0, res1);
 
@@ -417,7 +417,7 @@ contract UNIV2LPOracleTest is DSTest {
         log_named_uint("res1", res1);
 
         uint256 gasUse1 = preGas - postGas;
-        uint256 normalize_product = mul(dec0, dec1);
+        uint256 normalize_product = mul(normalizer0, normalizer1);
         uint256 preGas2 = gasleft();
 
         uint256 k_alt =

--- a/src/UNIV2LPOracle.t.sol
+++ b/src/UNIV2LPOracle.t.sol
@@ -362,9 +362,6 @@ contract UNIV2LPOracleTest is DSTest {
         // Since we have confidence in Babylonian method, we simply check for equivalence
         assertEq(rootVal, rootAltVal);
     }
-
-
-
     uint112 max112 = type(uint112).max;
 
     function test_seek_equivalence(

--- a/src/UNIV2LPOracle.t.sol
+++ b/src/UNIV2LPOracle.t.sol
@@ -396,17 +396,18 @@ contract UNIV2LPOracleTest is DSTest {
         uint112 res11 = res1;
         uint256 preGas = gasleft();
 
-        uint256 normalizer0 = 10**(18 - normalization1);
-        uint256 normalizer1 = 10**(18 - normalization0);
+        uint256 normalizer0 = 10**(18 - dec0);
+        uint256 normalizer1 = 10**(18 - dec1);
         // log_named_uint("Normalizer 0", normalizer0);
         // log_named_uint("Normalizer 1", normalizer1);
 
         // log_named_uint("res0 uncasted", mul(res0, normalizer0));
         // log_named_uint("max1 112 fill", max112);
         // log_named_uint("res1 uncasted", mul(res1, normalizer1));
-
-        uint256 res0 = mul(res0, normalizer0);
-        uint256 res1 = mul(res1, normalizer1);
+        uint256 res0 = uint256(res0);
+        uint256 res1 = uint256(res1);
+        if (dec0 > 1) res0 = mul(res0, dec0);
+        if (dec1 > 1) res1 = mul(res1, dec1);
 
         uint256 k = mul(res0, res1);
 
@@ -416,7 +417,7 @@ contract UNIV2LPOracleTest is DSTest {
         log_named_uint("res1", res1);
 
         uint256 gasUse1 = preGas - postGas;
-        uint256 normalize_product = mul(normalizer0, normalizer1);
+        uint256 normalize_product = mul(dec0, dec1);
         uint256 preGas2 = gasleft();
 
         uint256 k_alt =


### PR DESCRIPTION
Adding a `requires` for now to ensure that a cast will not result in an overflow, and failing if this is not the case.

While this mitigates that overflow risk, I believe it is not the best solution & I spent a good amount of time thinking of others. I will open an issue for further discussion, though, since the solution is outside the scope of audit-related fix.