### PR TITLE
CVF-58: Fix overflow from cast to uint128

### DIFF
--- a/src/UNIV2LPOracle.sol
+++ b/src/UNIV2LPOracle.sol
@@ -256,11 +256,11 @@ contract UNIV2LPOracle {
 
         // Get LP token supply
         uint256 supply = ERC20Like(src).totalSupply();
-        uint256 preq = mul(2 * WAD, sqrt(wmul(k, wmul(val0, val1))))
-                    / supply;
 
-        require(preq <= ((2 ** 128) - 1), "UNIV2LPOracle/quote-overflow");
         // No need to check that the supply is nonzero, Solidity reverts on division by zero.
+        uint256 preq = mul(2 * WAD, sqrt(wmul(k, wmul(val0, val1)))) / supply;
+
+        require(preq < 2 ** 128, "UNIV2LPOracle/quote-overflow");
         quote = uint128(preq);
     }
 

--- a/src/UNIV2LPOracle.sol
+++ b/src/UNIV2LPOracle.sol
@@ -256,12 +256,12 @@ contract UNIV2LPOracle {
 
         // Get LP token supply
         uint256 supply = ERC20Like(src).totalSupply();
+        uint256 preq = mul(2 * WAD, sqrt(wmul(k, wmul(val0, val1))))
+                    / supply;
 
+        require(preq <= ((2 ** 128) - 1), "UNIV2LPOracle/quote-overflow");
         // No need to check that the supply is nonzero, Solidity reverts on division by zero.
-        quote = uint128(
-                mul(2 * WAD, sqrt(wmul(k, wmul(val0, val1))))
-                    / supply
-        );
+        quote = uint128(preq);
     }
 
     function poke() external stoppable {


### PR DESCRIPTION
Adding a requires to prevent overflow from casting to uint128. While this solves the overflow risk, I think there is a better solution but it's outside the scope of addressing this feedback. Will create a separate PR or issue for discussion, since it involves other dependencies.