### PR TITLE
CFV-51: make seek less overflow-prone

### DIFF
--- a/src/UNIV2LPOracle.sol
+++ b/src/UNIV2LPOracle.sol
@@ -252,11 +252,11 @@ contract UNIV2LPOracle {
         // This calculation should be overflow-resistant even for tokens with very high or very
         // low prices, as the dollar value of each reserve should lie in a fairly controlled range
         // regardless of the token prices.
-        uint256 value0 = mul(p0, uint256(r0)) / UNIT_0;
-        uint256 value1 = mul(p1, uint256(r1)) / UNIT_1;
+        uint256 value0 = mul(p0, uint256(r0)) / UNIT_0;  // WAD
+        uint256 value1 = mul(p1, uint256(r1)) / UNIT_1;  // WAD
         uint256 preq = mul(2 * WAD, sqrt(mul(value0, value1))) / supply;  // Will revert if supply == 0
         require(preq < 2 ** 128, "UNIV2LPOracle/quote-overflow");
-        quote = uint128(preq);
+        quote = uint128(preq);  // WAD
     }
 
     function poke() external stoppable {

--- a/src/UNIV2LPOracle.sol
+++ b/src/UNIV2LPOracle.sol
@@ -129,17 +129,8 @@ contract UNIV2LPOracle {
     function add(uint x, uint y) internal pure returns (uint z) {
         require((z = x + y) >= x, "ds-math-add-overflow");
     }
-    function sub(uint x, uint y) internal pure returns (uint z) {
-        require((z = x - y) <= x, "ds-math-sub-underflow");
-    }
     function mul(uint x, uint y) internal pure returns (uint z) {
         require(y == 0 || (z = x * y) / y == x, "ds-math-mul-overflow");
-    }
-    function wmul(uint x, uint y) internal pure returns (uint z) {
-        z = add(mul(x, y), WAD / 2) / WAD;
-    }
-    function wdiv(uint x, uint y) internal pure returns (uint z) {
-        z = add(mul(x, WAD), y / 2) / y;
     }
 
     // FROM https://github.com/abdk-consulting/abdk-libraries-solidity/blob/16d7e1dd8628dfa2f88d5dadab731df7ada70bdd/ABDKMath64x64.sol#L687

--- a/src/UNIV2LPOracle.sol
+++ b/src/UNIV2LPOracle.sol
@@ -250,8 +250,9 @@ contract UNIV2LPOracle {
         // Get LP token supply
         uint256 supply = ERC20Like(src).totalSupply();
 
-        // The structure of this calculation should work well even for tokens with very high or very low prices,
-        // as the dollar value of each reserve should lie in a fairly controlled range regardless of the token prices.
+        // This calculation should be overflow-resistant even for tokens with very high or very
+        // low prices, as the dollar value of each reserve should lie in a fairly controlled range
+        // regardless of the token prices.
         uint256 value0 = mul(p0, uint256(res0)) / UNIT_0;
         uint256 value1 = mul(p1, uint256(res1)) / UNIT_1;
         uint256 preq = mul(2 * WAD, sqrt(mul(value0, value1))) / supply;  // Will revert if supply == 0

--- a/src/UNIV2LPOracle.sol
+++ b/src/UNIV2LPOracle.sol
@@ -237,7 +237,7 @@ contract UNIV2LPOracle {
         UniswapV2PairLike(src).sync();
 
         // Get reserves of uniswap liquidity pool
-        (uint112 r0, uint112 r1, uint32 ts) = UniswapV2PairLike(src).getReserves();
+        (uint112 r0, uint112 r1,) = UniswapV2PairLike(src).getReserves();
         require(r0 > 0 && r1 > 0, "UNIV2LPOracle/invalid-reserves");
 
         // All Oracle prices are priced with 18 decimals against USD

--- a/src/UNIV2LPOracle.sol
+++ b/src/UNIV2LPOracle.sol
@@ -25,27 +25,37 @@
 
 // Two-asset constant product pools, neglecting fees, satisfy (before and after trades):
 //
-// r_0 * r_1 = k                (1)
+// r_0 * r_1 = k                                    (1)
 //
 // where r_0 and r_1 are the reserves of the two tokens held by the pool.
 // The price of LP tokens (i.e. pool shares) needs to be evaluated based on 
 // reserve values r_0 and r_1 that cannot be arbitraged, i.e. values that
 // give the two halves of the pool equal economic value:
 //
-// r_0 * p_0 = r_1 * p_1        (2)
+// r_0 * p_0 = r_1 * p_1                            (2)
 // 
 // (p_i is the price of pool asset i in some reference unit of account).
 // Using (1) and (2) we can compute the arbitrage-free reserve values in a manner
 // that depends only on k (which can be derived from the current reserve balances,
 // even if they are far from equilibrium) and market prices p_i obtained from a trusted source:
 //
-// r_0 = sqrt(k * p_1 / p_0)    (3)
+// R_0 = sqrt(k * p_1 / p_0)                        (3)
 //   and
-// r_1 = sqrt(k * p_0 / p_1)    (4)
+// R_1 = sqrt(k * p_0 / p_1)                        (4)
 //
 // The value of an LP token is then, combining (3) and (4):
 //
-// (p_0 * r_0 + p_1 * r_1) / LP_supply = 2 * sqrt(k * p_0 * p_1) / LP_supply
+// (p_0 * R_0 + p_1 * R_1) / LP_supply
+//     = 2 * sqrt(k * p_0 * p_1) / LP_supply        (5)
+//
+// (5) can be re-expressed in terms of the current pool reserves r_0 and r_1:
+//
+// 2 * sqrt((r_0 * p_0) * (r_1 * p_1)) / LP_supply  (6)
+//
+// The structure of (6) is well-suited for use in fixed-point EVM calculations, as the
+// terms (r_0 * p_0) and (r_1 * p_1), being the values of the reserves in the reference unit,
+// should have reasonably-bounded sizes. This reduces the likelihood of overflow due to
+// tokens with very low prices but large total supplies.
 
 pragma solidity =0.6.12;
 

--- a/src/UNIV2LPOracle.sol
+++ b/src/UNIV2LPOracle.sol
@@ -239,7 +239,6 @@ contract UNIV2LPOracle {
         // Get reserves of uniswap liquidity pool
         (uint112 r0, uint112 r1, uint32 ts) = UniswapV2PairLike(src).getReserves();
         require(r0 > 0 && r1 > 0, "UNIV2LPOracle/invalid-reserves");
-        require(ts == block.timestamp);
 
         // All Oracle prices are priced with 18 decimals against USD
         uint256 p0 = OracleLike(orb0).read();  // Query token0 price from oracle (WAD)

--- a/src/UNIV2LPOracle.sol
+++ b/src/UNIV2LPOracle.sol
@@ -237,8 +237,8 @@ contract UNIV2LPOracle {
         UniswapV2PairLike(src).sync();
 
         // Get reserves of uniswap liquidity pool
-        (uint112 res0, uint112 res1, uint32 ts) = UniswapV2PairLike(src).getReserves();
-        require(res0 > 0 && res1 > 0, "UNIV2LPOracle/invalid-reserves");
+        (uint112 r0, uint112 r1, uint32 ts) = UniswapV2PairLike(src).getReserves();
+        require(r0 > 0 && r1 > 0, "UNIV2LPOracle/invalid-reserves");
         require(ts == block.timestamp);
 
         // All Oracle prices are priced with 18 decimals against USD
@@ -253,8 +253,8 @@ contract UNIV2LPOracle {
         // This calculation should be overflow-resistant even for tokens with very high or very
         // low prices, as the dollar value of each reserve should lie in a fairly controlled range
         // regardless of the token prices.
-        uint256 value0 = mul(p0, uint256(res0)) / UNIT_0;
-        uint256 value1 = mul(p1, uint256(res1)) / UNIT_1;
+        uint256 value0 = mul(p0, uint256(r0)) / UNIT_0;
+        uint256 value1 = mul(p1, uint256(r1)) / UNIT_1;
         uint256 preq = mul(2 * WAD, sqrt(mul(value0, value1))) / supply;  // Will revert if supply == 0
         require(preq < 2 ** 128, "UNIV2LPOracle/quote-overflow");
         quote = uint128(preq);

--- a/src/UNIV2LPOracle.sol
+++ b/src/UNIV2LPOracle.sol
@@ -243,8 +243,8 @@ contract UNIV2LPOracle {
 
         // All Oracle prices are priced with 18 decimals against USD
         uint256 p0 = OracleLike(orb0).read();  // Query token0 price from oracle (WAD)
-        uint256 p1 = OracleLike(orb1).read();  // Query token1 price from oracle (WAD)
         require(p0 != 0, "UNIV2LPOracle/invalid-oracle-0-price");
+        uint256 p1 = OracleLike(orb1).read();  // Query token1 price from oracle (WAD)
         require(p1 != 0, "UNIV2LPOracle/invalid-oracle-1-price");
 
         // Get LP token supply

--- a/src/UNIV2LPOracle.sol
+++ b/src/UNIV2LPOracle.sol
@@ -117,8 +117,8 @@ contract UNIV2LPOracle {
     modifier stoppable { require(stopped == 0, "UNIV2LPOracle/is-stopped"); _; }
 
     // --- Data ---
-    uint256 private immutable PREC_0;  // Precision (10^decimals) of token0
-    uint256 private immutable PREC_1;  // Precision (10^decimals) of token1
+    uint256 private immutable UNIT_0;  // Numerical representation of one token of token0 (10^decimals) 
+    uint256 private immutable UNIT_1;  // Numerical representation of one token of token1 (10^decimals) 
 
     address public            orb0;  // Oracle for token0, ideally a Medianizer
     address public            orb1;  // Oracle for token1, ideally a Medianizer
@@ -188,10 +188,10 @@ contract UNIV2LPOracle {
         wat  = _wat;
         uint256 dec0 = uint256(ERC20Like(UniswapV2PairLike(_src).token0()).decimals());
         require(dec0 <= 18, "UNIV2LPOracle/token0-dec-gt-18");
-        PREC_0 = 10 ** dec0;
+        UNIT_0 = 10 ** dec0;
         uint256 dec1 = uint256(ERC20Like(UniswapV2PairLike(_src).token1()).decimals());
         require(dec1 <= 18, "UNIV2LPOracle/token1-dec-gt-18");
-        PREC_1 = 10 ** dec1;
+        UNIT_1 = 10 ** dec1;
         orb0 = _orb0;
         orb1 = _orb1;
     }
@@ -251,8 +251,8 @@ contract UNIV2LPOracle {
 
         // The structure of this calculation should work well even for tokens with very high or very low prices,
         // as the dollar value of each reserve should lie in a fairly controlled range regardless of the token prices.
-        uint256 value0 = mul(p0, uint256(res0)) / PREC_0;
-        uint256 value1 = mul(p1, uint256(res1)) / PREC_1;
+        uint256 value0 = mul(p0, uint256(res0)) / UNIT_0;
+        uint256 value1 = mul(p1, uint256(res1)) / UNIT_1;
         uint256 preq = mul(2 * WAD, sqrt(mul(value0, value1))) / supply;  // Will revert if supply == 0
         require(preq < 2 ** 128, "UNIV2LPOracle/quote-overflow");
         quote = uint128(preq);


### PR DESCRIPTION
See updated comments for explanation.

There is one irrelevant commit in this PR: removing `require(ts == block.timestamp` from `seek`. A quick read of the Uniswap v2 code is sufficient to show this is useless at best: https://github.com/Uniswap/uniswap-v2-core/blob/master/contracts/UniswapV2Pair.sol . OTOH, removing it will save a little gas. I slipped it into this PR since I was touching `seek` anyway, but happy to move it to its own PR if that is preferred.